### PR TITLE
Scraping server의 응답으로 `null` 값이 응답될 때, 부족한 `null` 예외처리 로직 추가

### DIFF
--- a/src/main/java/com/zelusik/eatery/dto/place/PlaceScrapingResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/place/PlaceScrapingResponse.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.dto.place;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.lang.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -11,8 +12,13 @@ import java.util.Map;
 @Getter
 public class PlaceScrapingResponse {
 
+    @Nullable
     private List<PlaceScrapingOpeningHourDto> openingHours;
+
+    @Nullable
     private String closingHours;
+
+    @Nullable
     private String homepageUrl;
 
     public static PlaceScrapingResponse of(List<PlaceScrapingOpeningHourDto> openingHours, String closingHours, String homepageUrl) {
@@ -23,12 +29,12 @@ public class PlaceScrapingResponse {
     // TODO: Object => List<Map> 변환 로직이 있어서 generic type casting 문제를 무시한다. 더 좋은 방법이 있다면 고려할 수 있음.
     public static PlaceScrapingResponse from(Map<String, Object> attributes) {
         List<Map<String, Object>> openingHours = (List<Map<String, Object>>) attributes.get("openingHours");
+        Object closingHours = attributes.get("closingHours");
+        Object homepageUrl = attributes.get("homepageUrl");
         return of(
-                openingHours.stream()
-                        .map(PlaceScrapingOpeningHourDto::from)
-                        .toList(),
-                String.valueOf(attributes.get("closingHours")),
-                String.valueOf(attributes.get("homepageUrl"))
+                openingHours != null ? openingHours.stream().map(PlaceScrapingOpeningHourDto::from).toList() : null,
+                closingHours != null ? closingHours.toString() : null,
+                homepageUrl != null ? homepageUrl.toString() : null
         );
     }
 }

--- a/src/main/java/com/zelusik/eatery/service/PlaceService.java
+++ b/src/main/java/com/zelusik/eatery/service/PlaceService.java
@@ -54,11 +54,13 @@ public class PlaceService {
                 .toDto(scrapingInfo.getHomepageUrl(), scrapingInfo.getClosingHours())
                 .toEntity());
 
-        List<OpeningHours> openingHoursList = scrapingInfo.getOpeningHours().stream()
-                .map(oh -> oh.toOpeningHoursEntity(place))
-                .toList();
-        openingHoursRepository.saveAll(openingHoursList);
-        place.getOpeningHoursList().addAll(openingHoursList);
+        if (scrapingInfo.getOpeningHours() != null) {
+            List<OpeningHours> openingHoursList = scrapingInfo.getOpeningHours().stream()
+                    .map(oh -> oh.toOpeningHoursEntity(place))
+                    .toList();
+            openingHoursRepository.saveAll(openingHoursList);
+            place.getOpeningHoursList().addAll(openingHoursList);
+        }
 
         List<Long> markedPlaceIdList = bookmarkRepository.findAllMarkedPlaceId(memberId);
         return PlaceDtoWithMarkedStatus.from(place, markedPlaceIdList);


### PR DESCRIPTION
## 🔥 Related Issue
- Close #194

## 🏃‍ Task
- 영업시간이 null인 경우에 대한 예외처리
- 휴무일, 홈페이지 주소가 null인 경우 DB에 null이 그대로 저장될 수 있도록 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
