### PR TITLE
회원 역할 부여 및 일부 API의 접근 권한 설정

### DIFF
--- a/src/main/java/com/zelusik/eatery/config/SecurityConfig.java
+++ b/src/main/java/com/zelusik/eatery/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.zelusik.eatery.config;
 
+import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.security.JwtAccessDeniedHandler;
 import com.zelusik.eatery.security.JwtAuthenticationEntryPoint;
 import com.zelusik.eatery.security.JwtAuthenticationFilter;
@@ -16,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.util.Arrays;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -27,29 +29,33 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
-    private static final String BASE_URL = "/api";
-    private static final String[] AUTH_WHITE_LIST = {
-            "/auth/login/**",
-            "/auth/token",
-            "/auth/validity"
+    private static final String[] AUTH_WHITE_PATHS = {
+            "/api/auth/login/**",
+            "/api/auth/token",
+            "/api/auth/validity"
     };
+
+    private static final Map<String, HttpMethod> MANAGER_AUTH_LIST = Map.of(
+            "/api/curation/**", HttpMethod.POST
+    );
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        String[] rolesAboveManager = {RoleType.MANAGER.name(), RoleType.ADMIN.name()};
+
         return http
                 .httpBasic().disable()
                 .csrf().disable()
                 .formLogin().disable()
-                // JWT 기반 인증이기 때문에 session 사용 x
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()   // JWT 기반 인증이기 때문에 session 사용 x
                 .authorizeHttpRequests(auth -> {
-                            auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                                    .mvcMatchers("/swagger-ui/**", "/v3/api-docs/**", "/actuator/**").permitAll()
-                                    .mvcMatchers(HttpMethod.GET, BASE_URL + "/curation").permitAll();
-                            Arrays.stream(AUTH_WHITE_LIST).forEach(authWhiteListElem -> auth.mvcMatchers(BASE_URL + authWhiteListElem).permitAll());
-                            auth.anyRequest().authenticated();
-                        }
-                )
+                    auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                            .mvcMatchers("/swagger-ui/**", "/v3/api-docs/**", "/actuator/**").permitAll()
+                            .mvcMatchers(HttpMethod.GET, "/api/curation").permitAll();
+                    Arrays.stream(AUTH_WHITE_PATHS).forEach(authWhiteListElem -> auth.mvcMatchers(authWhiteListElem).permitAll());
+                    MANAGER_AUTH_LIST.forEach((path, httpMethod) -> auth.mvcMatchers(httpMethod, path).hasAnyRole(rolesAboveManager));
+                    auth.anyRequest().authenticated();
+                })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter, jwtAuthenticationFilter.getClass())
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer

--- a/src/main/java/com/zelusik/eatery/constant/member/RoleType.java
+++ b/src/main/java/com/zelusik/eatery/constant/member/RoleType.java
@@ -12,6 +12,6 @@ public enum RoleType {
     ADMIN("ROLE_ADMIN", "관리자"),
     ;
 
-    private final String name;
+    private final String roleName;
     private final String description;
 }

--- a/src/main/java/com/zelusik/eatery/constant/member/RoleType.java
+++ b/src/main/java/com/zelusik/eatery/constant/member/RoleType.java
@@ -1,16 +1,17 @@
 package com.zelusik.eatery.constant.member;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
+@Getter
 public enum RoleType {
-    
-    USER("ROLE_USER"),
-    ADMIN("ROLE_ADMIN");
 
-    @Getter
+    USER("ROLE_USER", "사용자"),
+    MANAGER("ROLE_MANAGER", "운영자"),
+    ADMIN("ROLE_ADMIN", "관리자"),
+    ;
+
     private final String name;
-
-    RoleType(String name) {
-        this.name = name;
-    }
+    private final String description;
 }

--- a/src/main/java/com/zelusik/eatery/controller/AuthController.java
+++ b/src/main/java/com/zelusik/eatery/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.zelusik.eatery.controller;
 
 import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.dto.apple.AppleOAuthUserResponse;
 import com.zelusik.eatery.dto.kakao.KakaoOAuthUserResponse;
 import com.zelusik.eatery.dto.auth.request.AppleLoginRequest;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import java.util.Set;
 
 @Tag(name = "로그인 등 인증 관련")
 @RequiredArgsConstructor
@@ -57,7 +59,7 @@ public class AuthController {
         KakaoOAuthUserResponse userInfo = kakaoService.getUserInfo(request.getKakaoAccessToken());
 
         MemberDto memberDto = memberService.findOptionalDtoBySocialUidWithDeleted(userInfo.getSocialUid())
-                .orElseGet(() -> memberService.save(userInfo.toMemberDto()));
+                .orElseGet(() -> memberService.save(userInfo.toMemberDto(Set.of(RoleType.USER))));
 
         if (memberDto.getDeletedAt() != null) {
             memberService.rejoin(memberDto.getId());
@@ -86,7 +88,7 @@ public class AuthController {
         AppleOAuthUserResponse userInfo = appleOAuthService.getUserInfo(request.getIdentityToken());
 
         MemberDto memberDto = memberService.findOptionalDtoBySocialUidWithDeleted(userInfo.getSub())
-                .orElseGet(() -> memberService.save(userInfo.toMemberDto(request.getName())));
+                .orElseGet(() -> memberService.save(userInfo.toMemberDto(request.getName(), Set.of(RoleType.USER))));
 
         if (memberDto.getDeletedAt() != null) {
             memberService.rejoin(memberDto.getId());

--- a/src/main/java/com/zelusik/eatery/controller/CurationController.java
+++ b/src/main/java/com/zelusik/eatery/controller/CurationController.java
@@ -81,7 +81,7 @@ public class CurationController {
                     example = "1"
             ) @PathVariable Long curationId
     ) {
-        return CurationResponse.from(CurationDto.from(curationService.findEntityById(curationId)));
+        return CurationResponse.from(curationService.findDtoById(curationId));
     }
 
     @Operation(

--- a/src/main/java/com/zelusik/eatery/controller/CurationController.java
+++ b/src/main/java/com/zelusik/eatery/controller/CurationController.java
@@ -63,11 +63,9 @@ public class CurationController {
             @ParameterObject @Valid @ModelAttribute CurationElemCreateRequest request
     ) {
         CurationResponse response = CurationResponse.from(curationService.addCurationElem(userPrincipal.getMemberId(), curationId, request));
-        List<CurationElemResponse> curationElems = response.getCurationElems();
-        Long newCurationElemId = curationElems.get(curationElems.size() - 1).getId();
 
         return ResponseEntity
-                .created(URI.create("/api/curation/" + newCurationElemId))
+                .created(URI.create("/api/curation/" + curationId)) // TODO: 새로 생성된 큐레이션 콘텐츠에 접근할 수 있는 uri로 변경되어야 함
                 .body(response);
     }
 

--- a/src/main/java/com/zelusik/eatery/converter/ReviewKeywordValueConverter.java
+++ b/src/main/java/com/zelusik/eatery/converter/ReviewKeywordValueConverter.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.util.domain;
+package com.zelusik.eatery.converter;
 
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 

--- a/src/main/java/com/zelusik/eatery/converter/RoleTypesConverter.java
+++ b/src/main/java/com/zelusik/eatery/converter/RoleTypesConverter.java
@@ -1,0 +1,30 @@
+package com.zelusik.eatery.converter;
+
+import com.zelusik.eatery.constant.member.RoleType;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Converter
+public class RoleTypesConverter implements AttributeConverter<Set<RoleType>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(Set<RoleType> attribute) {
+        return attribute.stream()
+                .map(RoleType::name)
+                .sorted()
+                .collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public Set<RoleType> convertToEntityAttribute(String dbData) {
+        return Arrays.stream(dbData.split(DELIMITER))
+                .map(RoleType::valueOf)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/member/Member.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/Member.java
@@ -2,6 +2,8 @@ package com.zelusik.eatery.domain.member;
 
 import com.zelusik.eatery.constant.member.Gender;
 import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
+import com.zelusik.eatery.converter.RoleTypesConverter;
 import com.zelusik.eatery.domain.BaseTimeEntity;
 import lombok.*;
 
@@ -10,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -44,6 +47,10 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private LoginType loginType;
 
+    @Column(nullable = false)
+    @Convert(converter = RoleTypesConverter.class)
+    private Set<RoleType> roleTypes;
+
     @Column(unique = true)
     private String email;
 
@@ -66,11 +73,11 @@ public class Member extends BaseTimeEntity {
     @Setter(AccessLevel.PRIVATE)
     private LocalDateTime deletedAt;
 
-    public static Member of(String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender) {
-        return of(null, null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, email, nickname, null, ageRange, gender, null, null, null);
+    public static Member of(String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, Set<RoleType> roleTypes, String email, String nickname, Integer ageRange, Gender gender) {
+        return of(null, null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, null, ageRange, gender, null, null, null);
     }
 
-    public static Member of(Long id, TermsInfo termsInfo, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, LocalDate birthDay, Integer ageRange, Gender gender, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+    public static Member of(Long id, TermsInfo termsInfo, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, Set<RoleType> roleTypes, String email, String nickname, LocalDate birthDay, Integer ageRange, Gender gender, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         return Member.builder()
                 .id(id)
                 .termsInfo(termsInfo)
@@ -78,6 +85,7 @@ public class Member extends BaseTimeEntity {
                 .profileThumbnailImageUrl(profileThumbnailImageUrl)
                 .socialUid(socialUid)
                 .loginType(loginType)
+                .roleTypes(roleTypes)
                 .email(email)
                 .nickname(nickname)
                 .ageRange(ageRange)
@@ -120,7 +128,7 @@ public class Member extends BaseTimeEntity {
     }
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Member(Long id, TermsInfo termsInfo, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, LocalDate birthDay, Integer ageRange, Gender gender, LocalDateTime deletedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Member(Long id, TermsInfo termsInfo, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, Set<RoleType> roleTypes, String email, String nickname, LocalDate birthDay, Integer ageRange, Gender gender, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         super(createdAt, updatedAt);
         this.id = id;
         this.termsInfo = termsInfo;
@@ -128,6 +136,7 @@ public class Member extends BaseTimeEntity {
         this.profileThumbnailImageUrl = profileThumbnailImageUrl;
         this.socialUid = socialUid;
         this.loginType = loginType;
+        this.roleTypes = roleTypes;
         this.email = email;
         this.nickname = nickname;
         this.birthDay = birthDay;

--- a/src/main/java/com/zelusik/eatery/domain/place/Place.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/Place.java
@@ -3,7 +3,7 @@ package com.zelusik.eatery.domain.place;
 import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.BaseTimeEntity;
-import com.zelusik.eatery.util.domain.ReviewKeywordValueConverter;
+import com.zelusik.eatery.converter.ReviewKeywordValueConverter;
 import lombok.*;
 
 import javax.persistence.*;

--- a/src/main/java/com/zelusik/eatery/dto/apple/AppleOAuthUserResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/apple/AppleOAuthUserResponse.java
@@ -3,12 +3,15 @@ package com.zelusik.eatery.dto.apple;
 import com.zelusik.eatery.constant.ConstantUtil;
 import com.zelusik.eatery.constant.member.Gender;
 import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.dto.member.MemberDto;
 import com.zelusik.eatery.util.NicknameGenerator;
 import io.jsonwebtoken.Claims;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Set;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -28,12 +31,13 @@ public class AppleOAuthUserResponse {
         );
     }
 
-    public MemberDto toMemberDto(String name) {
+    public MemberDto toMemberDto(String name, Set<RoleType> roleTypes) {
         return MemberDto.of(
                 ConstantUtil.defaultProfileImageUrl,
                 ConstantUtil.defaultProfileThumbnailImageUrl,
                 this.getSub(),
                 LoginType.APPLE,
+                roleTypes,
                 this.getEmail(),
                 name != null ? name : NicknameGenerator.generateRandomNickname(),
                 null,

--- a/src/main/java/com/zelusik/eatery/dto/curation/request/CurationCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/curation/request/CurationCreateRequest.java
@@ -5,10 +5,16 @@ import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class CurationCreateRequest {
 
     @Schema(description = "제목", example = "또간집 출연 맛집")
     @NotBlank
     private String title;
+
+    public static CurationCreateRequest of(String title) {
+        return new CurationCreateRequest(title);
+    }
 }

--- a/src/main/java/com/zelusik/eatery/dto/curation/request/CurationElemCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/curation/request/CurationElemCreateRequest.java
@@ -12,8 +12,12 @@ import org.springframework.web.multipart.MultipartFile;
 public class CurationElemCreateRequest {
 
     @Schema(description = "장소 정보")
-    PlaceCreateRequest place;
+    private PlaceCreateRequest place;
 
     @Schema(description = "장소에 대한 이미지")
     private MultipartFile image;
+
+    public static CurationElemCreateRequest of(PlaceCreateRequest place, MultipartFile image) {
+        return new CurationElemCreateRequest(place, image);
+    }
 }

--- a/src/main/java/com/zelusik/eatery/dto/kakao/KakaoOAuthUserResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/kakao/KakaoOAuthUserResponse.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.dto.kakao;
 import com.zelusik.eatery.constant.ConstantUtil;
 import com.zelusik.eatery.constant.member.Gender;
 import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.dto.member.MemberDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+import java.util.Set;
 
 @SuppressWarnings("unchecked")  // TODO: Map -> Object 변환 로직이 있어서 generic type casting 문제를 무시한다. 더 좋은 방법이 있다면 고려할 수 있음.
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -99,7 +101,7 @@ public class KakaoOAuthUserResponse {
         );
     }
 
-    public MemberDto toMemberDto() {
+    public MemberDto toMemberDto(Set<RoleType> roleTypes) {
         String profileImageUrl = getProfileImageUrl();
         if (profileImageUrl == null) {
             profileImageUrl = ConstantUtil.defaultProfileImageUrl;
@@ -115,6 +117,7 @@ public class KakaoOAuthUserResponse {
                 thumbnailImageUrl,
                 getSocialUid(),
                 LoginType.KAKAO,
+                roleTypes,
                 getEmail(),
                 getNickname(),
                 getAgeRange(),

--- a/src/main/java/com/zelusik/eatery/dto/member/MemberDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/member/MemberDto.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.dto.member;
 import com.zelusik.eatery.constant.FoodCategoryValue;
 import com.zelusik.eatery.constant.member.Gender;
 import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.domain.member.FavoriteFoodCategory;
 import com.zelusik.eatery.domain.member.Member;
 import com.zelusik.eatery.dto.terms_info.TermsInfoDto;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -26,6 +28,7 @@ public class MemberDto {
     private String profileThumbnailImageUrl;
     private String socialUid;
     private LoginType loginType;
+    private Set<RoleType> roleTypes;
     private String email;
     private String nickname;
     private LocalDate birthDay;
@@ -36,12 +39,12 @@ public class MemberDto {
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
-    public static MemberDto of(String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender) {
-        return of(null, null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, email, nickname, null, ageRange, gender, null, null, null, null);
+    public static MemberDto of(String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, Set<RoleType> roleTypes, String email, String nickname, Integer ageRange, Gender gender) {
+        return of(null, null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, null, ageRange, gender, null, null, null, null);
     }
 
-    public static MemberDto of(Long id, TermsInfoDto termsInfoDto, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, LocalDate birthDay, Integer ageRange, Gender gender, List<FoodCategoryValue> favoriteFoodCategories, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
-        return new MemberDto(id, termsInfoDto, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, email, nickname, birthDay, ageRange, gender, favoriteFoodCategories, createdAt, updatedAt, deletedAt);
+    public static MemberDto of(Long id, TermsInfoDto termsInfoDto, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, Set<RoleType> roleTypes, String email, String nickname, LocalDate birthDay, Integer ageRange, Gender gender, List<FoodCategoryValue> favoriteFoodCategories, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        return new MemberDto(id, termsInfoDto, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, birthDay, ageRange, gender, favoriteFoodCategories, createdAt, updatedAt, deletedAt);
     }
 
     public static MemberDto from(Member entity) {
@@ -52,6 +55,7 @@ public class MemberDto {
                 entity.getProfileThumbnailImageUrl(),
                 entity.getSocialUid(),
                 entity.getLoginType(),
+                entity.getRoleTypes(),
                 entity.getEmail(),
                 entity.getNickname(),
                 entity.getBirthDay(),
@@ -72,6 +76,7 @@ public class MemberDto {
                 this.getProfileThumbnailImageUrl(),
                 this.getSocialUid(),
                 this.getLoginType(),
+                this.getRoleTypes(),
                 this.getEmail(),
                 this.getNickname(),
                 this.getAgeRange(),

--- a/src/main/java/com/zelusik/eatery/dto/member/response/MemberResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/member/response/MemberResponse.java
@@ -2,6 +2,7 @@ package com.zelusik.eatery.dto.member.response;
 
 import com.zelusik.eatery.constant.FoodCategoryValue;
 import com.zelusik.eatery.constant.member.Gender;
+import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.dto.file.response.ImageResponse;
 import com.zelusik.eatery.dto.member.MemberDto;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +12,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -18,6 +20,9 @@ public class MemberResponse {
 
     @Schema(description = "회원 id(PK)", example = "1")
     private Long id;
+
+    @Schema(description = "회원에게 부여된 역할들", example = "사용자, 운영자")
+    private String roleTypes;
 
     @Schema(description = "프로필 이미지")
     private ImageResponse image;
@@ -37,9 +42,10 @@ public class MemberResponse {
     @Schema(description = "선호 음식 카테고리 목록", example = "[\"한식\", \"중식\"]")
     private List<String> favoriteFoodCategories;
 
-    public static MemberResponse of(Long id, ImageResponse image, String email, String nickname, Gender gender, LocalDate birthDay, List<FoodCategoryValue> favoriteFoodCategories) {
+    public static MemberResponse of(Long id, String roleTypes, ImageResponse image, String email, String nickname, Gender gender, LocalDate birthDay, List<FoodCategoryValue> favoriteFoodCategories) {
         return new MemberResponse(
                 id,
+                roleTypes,
                 image,
                 email,
                 nickname,
@@ -54,6 +60,9 @@ public class MemberResponse {
     public static MemberResponse from(MemberDto dto) {
         return of(
                 dto.getId(),
+                dto.getRoleTypes().stream()
+                        .map(RoleType::getDescription)
+                        .collect(Collectors.joining(", ")),
                 ImageResponse.of(dto.getProfileImageUrl(), dto.getProfileThumbnailImageUrl()),
                 dto.getEmail(),
                 dto.getNickname(),

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -11,7 +11,7 @@ import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.dto.place.PlaceDtoWithMarkedStatusAndImages;
 import com.zelusik.eatery.dto.place.PlaceFilteringKeywordDto;
 import com.zelusik.eatery.dto.review.ReviewImageDto;
-import com.zelusik.eatery.util.domain.ReviewKeywordValueConverter;
+import com.zelusik.eatery.converter.ReviewKeywordValueConverter;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;

--- a/src/main/java/com/zelusik/eatery/security/JwtTokenProvider.java
+++ b/src/main/java/com/zelusik/eatery/security/JwtTokenProvider.java
@@ -141,7 +141,7 @@ public class JwtTokenProvider {
         String token = Jwts.builder()
                 .setHeaderParam("typ", "JWT")
                 .setSubject(String.valueOf(memberId))
-                .claim(ROLE_CLAIM_KEY, roleType.getName())
+                .claim(ROLE_CLAIM_KEY, roleType.getRoleName())
                 .claim(LOGIN_TYPE_CLAIM_KEY, loginType.name())
                 .setIssuedAt(now)
                 .setExpiration(expiresAt)

--- a/src/main/java/com/zelusik/eatery/security/UserPrincipal.java
+++ b/src/main/java/com/zelusik/eatery/security/UserPrincipal.java
@@ -23,7 +23,7 @@ public class UserPrincipal implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return memberDto.getRoleTypes().stream()
-                .map(RoleType::getName)
+                .map(RoleType::getRoleName)
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toUnmodifiableSet());
     }

--- a/src/main/java/com/zelusik/eatery/security/UserPrincipal.java
+++ b/src/main/java/com/zelusik/eatery/security/UserPrincipal.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserPrincipal implements UserDetails {
@@ -22,12 +22,10 @@ public class UserPrincipal implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        Set<RoleType> roleTypes = Set.of(RoleType.values());
-
-        return roleTypes.stream()
+        return memberDto.getRoleTypes().stream()
                 .map(RoleType::getName)
                 .map(SimpleGrantedAuthority::new)
-                .toList();
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     public Long getMemberId() {

--- a/src/main/java/com/zelusik/eatery/service/CurationService.java
+++ b/src/main/java/com/zelusik/eatery/service/CurationService.java
@@ -75,9 +75,13 @@ public class CurationService {
      * @param curationId 조회하고자 하는 큐레이션의 PK
      * @return 조회한 큐레이션 entity
      */
-    public Curation findEntityById(Long curationId) {
+    private Curation findEntityById(Long curationId) {
         return curationRepository.findById(curationId)
                 .orElseThrow(CurationNotFoundException::new);
+    }
+
+    public CurationDto findDtoById(Long curationId) {
+        return CurationDto.from(findEntityById(curationId));
     }
 
     /**

--- a/src/test/java/com/zelusik/eatery/controller/CurationControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/controller/CurationControllerTest.java
@@ -4,11 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zelusik.eatery.config.TestSecurityConfig;
 import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.dto.curation.CurationDto;
+import com.zelusik.eatery.dto.curation.CurationElemDto;
+import com.zelusik.eatery.dto.curation.CurationElemFileDto;
 import com.zelusik.eatery.dto.curation.request.CurationCreateRequest;
+import com.zelusik.eatery.dto.curation.request.CurationElemCreateRequest;
+import com.zelusik.eatery.dto.curation.response.CurationListResponse;
+import com.zelusik.eatery.dto.place.PlaceDtoWithMarkedStatus;
+import com.zelusik.eatery.dto.place.request.PlaceCreateRequest;
 import com.zelusik.eatery.security.UserPrincipal;
 import com.zelusik.eatery.service.CurationService;
 import com.zelusik.eatery.util.MemberTestUtils;
-import org.jetbrains.annotations.NotNull;
+import com.zelusik.eatery.util.MultipartFileTestUtils;
+import com.zelusik.eatery.util.PlaceTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,15 +23,19 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -60,7 +71,7 @@ class CurationControllerTest {
                         post("/api/curation")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(request))
-                                .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId(1L, Set.of(RoleType.USER, RoleType.MANAGER)))))
+                                .with(user(createTestUserDetails(1L, Set.of(RoleType.USER, RoleType.MANAGER))))
                 )
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(curationId))
@@ -85,12 +96,154 @@ class CurationControllerTest {
                 .andExpect(status().isForbidden());
     }
 
+    @DisplayName("큐레이션의 새로운 콘텐츠가 추가하고자 할 큐레이션 id와 함께 주어지고, 큐레이션에 콘텐츠를 추가하면, 콘텐츠가 추가된 큐레이션 정보가 반환된다.")
+    @Test
+    void givenNewCurationContentWithCurationId_whenAddContentToCuration_thenReturnUpdatedCuration() throws Exception {
+        // given
+        long memberId = 1L;
+        long curationId = 2L;
+        long placeId = 3L;
+        PlaceCreateRequest placeRequest = PlaceTestUtils.createPlaceRequest();
+        MockMultipartFile mockMultipartFile = MultipartFileTestUtils.createMockMultipartFile();
+        CurationDto expectedResult = createCurationDto(
+                curationId,
+                "test curation",
+                List.of(createCurationElemDto(4L, curationId, PlaceTestUtils.createPlaceDto(placeId)))
+        );
+        given(curationService.addCurationElem(eq(memberId), eq(curationId), any(CurationElemCreateRequest.class)))
+                .willReturn(expectedResult);
+
+        // when & then
+        mvc.perform(
+                        multipart("/api/curation/" + curationId)
+                                .file(mockMultipartFile)
+                                .param("place.kakaoPid", placeRequest.getKakaoPid())
+                                .param("place.name", placeRequest.getName())
+                                .param("place.pageUrl", placeRequest.getPageUrl())
+                                .param("place.categoryGroupCode", placeRequest.getCategoryGroupCode().toString())
+                                .param("place.categoryName", placeRequest.getCategoryName())
+                                .param("place.phone", placeRequest.getPhone())
+                                .param("place.lotNumberAddress", placeRequest.getLotNumberAddress())
+                                .param("place.roadAddress", placeRequest.getRoadAddress())
+                                .param("place.lat", placeRequest.getLat())
+                                .param("place.lng", placeRequest.getLng())
+                                .with(user(createTestUserDetails(memberId, Set.of(RoleType.USER, RoleType.MANAGER))))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(curationId))
+                .andExpect(jsonPath("$.curationElems").isArray())
+                .andExpect(jsonPath("$.curationElems.size()").value(1));
+    }
+
+    @DisplayName("일반 유저가 큐레이션에 콘텐츠를 추가하려고 하면, 접근이 거부된다.")
+    @Test
+    void givenNewCurationContentWithCurationId_whenAddContentToCurationWithNormalUser_thenThrowAccessDeniedException() throws Exception {
+        // given
+        long memberId = 1L;
+        long curationId = 2L;
+        MockMultipartFile mockMultipartFile = MultipartFileTestUtils.createMockMultipartFile();
+        PlaceCreateRequest placeRequest = PlaceTestUtils.createPlaceRequest();
+
+        // when & then
+        mvc.perform(
+                        multipart("/api/curation/" + curationId)
+                                .file(mockMultipartFile)
+                                .param("place.kakaoPid", placeRequest.getKakaoPid())
+                                .param("place.name", placeRequest.getName())
+                                .param("place.pageUrl", placeRequest.getPageUrl())
+                                .param("place.categoryGroupCode", placeRequest.getCategoryGroupCode().toString())
+                                .param("place.categoryName", placeRequest.getCategoryName())
+                                .param("place.phone", placeRequest.getPhone())
+                                .param("place.lotNumberAddress", placeRequest.getLotNumberAddress())
+                                .param("place.roadAddress", placeRequest.getRoadAddress())
+                                .param("place.lat", placeRequest.getLat())
+                                .param("place.lng", placeRequest.getLng())
+                                .with(user(createTestUserDetails(memberId, Set.of(RoleType.USER))))
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("큐레이션 id로 큐레이션 정보를 조회하면, 조회된 큐레이션 정보가 반환된다.")
+    @Test
+    void givenCurationId_whenFindingCuration_thenReturnCuration() throws Exception {
+        // given
+        long memberId = 1L;
+        long curationId = 2L;
+        CurationDto expectedCuration = createCurationDto(curationId, "test curation", List.of());
+        given(curationService.findDtoById(curationId)).willReturn(expectedCuration);
+
+        // when & then
+        mvc.perform(
+                        get("/api/curation/" + curationId)
+                                .with(user(createTestUserDetails(memberId, Set.of(RoleType.USER))))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(curationId));
+    }
+
+    @DisplayName("큐레이션 목록을 조회하면, 조회된 결과가 반환된다.")
+    @Test
+    void given_when_then() throws Exception {
+        // given
+        CurationListResponse expectedResult = CurationListResponse.of(List.of());
+        given(curationService.getCurationList()).willReturn(expectedResult);
+
+        // when & then
+        mvc.perform(
+                        get("/api/curation")
+                                .with(user(createTestUserDetails(1L, Set.of(RoleType.USER))))
+                )
+                .andExpect(status().isOk());
+    }
+
+    @NotNull
+    private static UserPrincipal createTestUserDetails(long memberId, Set<RoleType> roleTypes) {
+        return UserPrincipal.of(MemberTestUtils.createMemberDtoWithId(memberId, roleTypes));
+    }
+
     @NotNull
     private static CurationDto createCurationDto(Long id, String title) {
         return CurationDto.of(
                 id,
                 title,
                 List.of(),
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2023, 1, 1, 0, 0)
+        );
+    }
+
+    @NotNull
+    private static CurationDto createCurationDto(Long id, String title, List<CurationElemDto> curationElems) {
+        return CurationDto.of(
+                id,
+                title,
+                curationElems,
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2023, 1, 1, 0, 0)
+        );
+    }
+
+    @NotNull
+    private static CurationElemDto createCurationElemDto(Long newContentId, Long curationId, PlaceDtoWithMarkedStatus placeDto) {
+        return CurationElemDto.of(
+                newContentId,
+                curationId,
+                placeDto,
+                createCurationElemFileDto(),
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2023, 1, 1, 0, 0)
+        );
+    }
+
+    @NotNull
+    private static CurationElemFileDto createCurationElemFileDto() {
+        return CurationElemFileDto.of(
+                100L,
+                "original image name",
+                "image name stored to s3 bucket",
+                "image url",
+                "thumbnail image stored name",
+                "thumbnail image url",
                 LocalDateTime.of(2023, 1, 1, 0, 0),
                 LocalDateTime.of(2023, 1, 1, 0, 0)
         );

--- a/src/test/java/com/zelusik/eatery/controller/CurationControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/controller/CurationControllerTest.java
@@ -1,0 +1,98 @@
+package com.zelusik.eatery.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zelusik.eatery.config.TestSecurityConfig;
+import com.zelusik.eatery.constant.member.RoleType;
+import com.zelusik.eatery.dto.curation.CurationDto;
+import com.zelusik.eatery.dto.curation.request.CurationCreateRequest;
+import com.zelusik.eatery.security.UserPrincipal;
+import com.zelusik.eatery.service.CurationService;
+import com.zelusik.eatery.util.MemberTestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("[Unit] Curation Controller")
+@Import(TestSecurityConfig.class)
+@WebMvcTest(controllers = CurationController.class)
+class CurationControllerTest {
+
+    @MockBean
+    private CurationService curationService;
+
+    private final MockMvc mvc;
+    private final ObjectMapper mapper;
+
+    @Autowired
+    public CurationControllerTest(MockMvc mvc, ObjectMapper mapper) {
+        this.mvc = mvc;
+        this.mapper = mapper;
+    }
+
+    @DisplayName("큐레이션 제목과 함께, 큐레이션을 생성한다.")
+    @Test
+    void givenCurationTitle_whenCreateCuration_thenReturnCreatedCuration() throws Exception {
+        // given
+        long curationId = 2L;
+        String title = "test curation";
+        CurationCreateRequest request = CurationCreateRequest.of(title);
+        CurationDto expectedCreatedCuration = createCurationDto(curationId, title);
+        given(curationService.create(title)).willReturn(expectedCreatedCuration);
+
+        // when & then
+        mvc.perform(
+                        post("/api/curation")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(mapper.writeValueAsString(request))
+                                .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId(1L, Set.of(RoleType.USER, RoleType.MANAGER)))))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(curationId))
+                .andExpect(jsonPath("$.title").value(title))
+                .andExpect(jsonPath("$.curationElems").isArray());
+    }
+
+    @DisplayName("일반 유저가 큐레이션을 생성하려고 하면, 접근이 거부된다.")
+    @Test
+    void givenCurationTitle_whenCreateCurationWithNormalUser_thenThrowAccessDeniedException() throws Exception {
+        // given
+        String title = "test curation";
+        CurationCreateRequest request = CurationCreateRequest.of(title);
+
+        // when & then
+        mvc.perform(
+                        post("/api/curation")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(mapper.writeValueAsString(request))
+                                .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId(1L, Set.of(RoleType.USER)))))
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @NotNull
+    private static CurationDto createCurationDto(Long id, String title) {
+        return CurationDto.of(
+                id,
+                title,
+                List.of(),
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2023, 1, 1, 0, 0)
+        );
+    }
+}

--- a/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
@@ -51,7 +51,7 @@ public class MemberTestUtils {
 
     public static MemberDto createMemberDtoWithId(Long memberId, Set<RoleType> roleTypes) {
         return MemberDto.of(
-                1L,
+                memberId,
                 null,
                 ConstantUtil.defaultProfileImageUrl,
                 ConstantUtil.defaultProfileThumbnailImageUrl,

--- a/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
@@ -4,6 +4,7 @@ import com.zelusik.eatery.constant.ConstantUtil;
 import com.zelusik.eatery.constant.FoodCategoryValue;
 import com.zelusik.eatery.constant.member.Gender;
 import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
 import com.zelusik.eatery.constant.review.MemberDeletionSurveyType;
 import com.zelusik.eatery.domain.member.*;
 import com.zelusik.eatery.dto.member.MemberDeletionSurveyDto;
@@ -12,6 +13,7 @@ import com.zelusik.eatery.dto.member.MemberDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 public class MemberTestUtils {
 
@@ -22,11 +24,16 @@ public class MemberTestUtils {
     public static final Gender GENDER = Gender.MALE;
 
     public static MemberDto createMemberDto() {
+        return createMemberDto(Set.of(RoleType.USER));
+    }
+
+    public static MemberDto createMemberDto(Set<RoleType> roleTypes) {
         return MemberDto.of(
                 ConstantUtil.defaultProfileImageUrl,
                 ConstantUtil.defaultProfileThumbnailImageUrl,
                 SOCIAL_UID,
                 LoginType.KAKAO,
+                roleTypes,
                 EMAIL,
                 NICKNAME,
                 AGE_RANGE,
@@ -39,6 +46,10 @@ public class MemberTestUtils {
     }
 
     public static MemberDto createMemberDtoWithId(Long memberId) {
+        return createMemberDtoWithId(memberId, Set.of(RoleType.USER));
+    }
+
+    public static MemberDto createMemberDtoWithId(Long memberId, Set<RoleType> roleTypes) {
         return MemberDto.of(
                 1L,
                 null,
@@ -46,6 +57,7 @@ public class MemberTestUtils {
                 ConstantUtil.defaultProfileThumbnailImageUrl,
                 SOCIAL_UID,
                 LoginType.KAKAO,
+                roleTypes,
                 EMAIL,
                 NICKNAME,
                 LocalDate.of(1998, 1, 5),
@@ -67,6 +79,10 @@ public class MemberTestUtils {
     }
 
     public static Member createMember(Long memberId, TermsInfo termsInfo, LocalDateTime deletedAt) {
+        return createMember(memberId, termsInfo, Set.of(RoleType.USER), deletedAt);
+    }
+
+    public static Member createMember(Long memberId, TermsInfo termsInfo, Set<RoleType> roleTypes, LocalDateTime deletedAt) {
         Member member = Member.of(
                 memberId,
                 termsInfo,
@@ -74,6 +90,7 @@ public class MemberTestUtils {
                 ConstantUtil.defaultProfileThumbnailImageUrl,
                 SOCIAL_UID,
                 LoginType.KAKAO,
+                roleTypes,
                 EMAIL,
                 NICKNAME,
                 LocalDate.of(1998, 1, 5),
@@ -127,7 +144,7 @@ public class MemberTestUtils {
     }
 
     public static ProfileImage createProfileImage(Long profileImageId) {
-        return createProfileImage(createMember(1L),  profileImageId);
+        return createProfileImage(createMember(1L), profileImageId);
     }
 
     public static ProfileImage createProfileImage(Member member, Long profileImageId) {

--- a/src/test/java/com/zelusik/eatery/util/ReviewKeywordValueConverterTest.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewKeywordValueConverterTest.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.util;
 
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
-import com.zelusik.eatery.util.domain.ReviewKeywordValueConverter;
+import com.zelusik.eatery.converter.ReviewKeywordValueConverter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;


### PR DESCRIPTION
## 🔥 Related Issue
- Close #206

## 🏃‍ Task
-  `Member` entity에 역할(`RoleType`) 추가
  - Dto와 `UserPrincipal`에 이에 따른 변경사항 반영
- 접근 권한 제한이 필요한 API 점검
- Curation 생성 및 curation에 content를 추가하는 API에 대한 접근 제어 설정 (운영자 이상만 사용 가능하도록)

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
