### PR TITLE
fix: #218 Exception handler에서 Spring 기본 예외를 제대로 처리하지 못하는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/exception/ExceptionType.java
@@ -169,7 +169,7 @@ public enum ExceptionType {
 
     public static Optional<ExceptionType> from(Class<? extends Exception> classType) {
         Optional<ExceptionType> exceptionType = Arrays.stream(values())
-                .filter(ex -> ex.getType() != null && ex.getType().equals(classType))
+                .filter(ex -> ex.getType() != null && ex.getType().isAssignableFrom(classType))
                 .findFirst();
 
         if (exceptionType.isEmpty()) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #218 

## 🏃‍ Task
- Exception handler에서 Spring 기본 예외를 제대로 처리하지 못하는 버그 수정
  - 기존 `equals`로 exception의 class type을 비교하던 코드에서 `isAssignableFrom()`으로 class type을 비교하도록 변경하였다. 이렇게 함으로써 `ExceptionType`에 정의된 exception들의 하위 exception들까지 handling이 가능해진다.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
