### PR TITLE
북마크 조회 시 연관된 entity에 대해 fetch join 적용

### DIFF
--- a/src/main/java/com/zelusik/eatery/repository/bookmark/BookmarkRepository.java
+++ b/src/main/java/com/zelusik/eatery/repository/bookmark/BookmarkRepository.java
@@ -1,11 +1,10 @@
 package com.zelusik.eatery.repository.bookmark;
 
 import com.zelusik.eatery.domain.Bookmark;
-import com.zelusik.eatery.domain.member.Member;
 import com.zelusik.eatery.domain.place.Place;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Map;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
@@ -14,5 +13,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByMember_IdAndPlace_Id(Long memberId, Long placeId);
 
+    @EntityGraph(attributePaths = {"member", "place"})
     Optional<Bookmark> findByMember_IdAndPlace_Id(Long memberId, Long placeId);
 }


### PR DESCRIPTION
## 🏃‍ Task
- 북마크 조회 시 연관된 entity(`Member`, `Place`)에 대해 fetch join 적용
  - `BookmarkRepository`의 `findByMember_IdAndPlace_Id`가 주로 사용될 때는 `Bookmark`의 `Member`와 `Place`도 함께 사용되는 경우가 대부분이다. 그 때문에 `@EntityGraph`를 사용하여 연관된 entity들을 fetch join 하는 것이 좋다고 판단하였다.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
