### PR TITLE
회원 정보 수정 시 프로필 사진에 대해 원본 이미지만을 받아 썸네일용으로 리사이징 후 저장하도록 리팩토링

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.zelusik.eatery.controller;
 
 import com.zelusik.eatery.constant.FoodCategoryValue;
+import com.zelusik.eatery.dto.member.MemberDto;
 import com.zelusik.eatery.dto.member.request.FavoriteFoodCategoriesUpdateRequest;
 import com.zelusik.eatery.dto.member.request.MemberUpdateRequest;
 import com.zelusik.eatery.dto.member.request.TermsAgreeRequest;
@@ -80,12 +81,8 @@ public class MemberController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @ModelAttribute MemberUpdateRequest memberUpdateRequest
     ) {
-        return MemberResponse.from(
-                memberService.update(
-                        userPrincipal.getMemberId(),
-                        memberUpdateRequest
-                )
-        );
+        MemberDto updatedMember = memberService.update(userPrincipal.getMemberId(), memberUpdateRequest);
+        return MemberResponse.from(updatedMember);
     }
 
     @Operation(

--- a/src/main/java/com/zelusik/eatery/dto/member/request/MemberUpdateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/member/request/MemberUpdateRequest.java
@@ -1,18 +1,20 @@
 package com.zelusik.eatery.dto.member.request;
 
 import com.zelusik.eatery.constant.member.Gender;
-import com.zelusik.eatery.dto.ImageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Setter
 @Getter
 public class MemberUpdateRequest {
 
@@ -28,18 +30,6 @@ public class MemberUpdateRequest {
     @NotNull
     private Gender gender;
 
-    @Schema(description = "<p>변경하고자 하는 프로필 이미지" +
-            "<p>이미지 요청 데이터는 다음 두 개의 field로 구성됩니다." +
-            "<ul>" +
-            "<li><code>image</code>: 이미지</li>" +
-            "<li><code>thumbnailImage</code>: 리사이징된 썸네일 이미지</li>" +
-            "</ul>" +
-            "<p>요청 데이터 예시는 다음과 같습니다." +
-            "<p><code>profileImage.image = 이미지1</code>" +
-            "<p><code>profileImage.thumbnailImage = 이미지2</code>")
-    private ImageDto profileImage;
-
-    public static MemberUpdateRequest of(String nickname, LocalDate birthDay, Gender gender, ImageDto profileImage) {
-        return new MemberUpdateRequest(nickname, birthDay, gender, profileImage);
-    }
+    @Schema(description = "변경하고자 하는 프로필 이미지")
+    private MultipartFile profileImage;
 }

--- a/src/main/java/com/zelusik/eatery/service/MemberService.java
+++ b/src/main/java/com/zelusik/eatery/service/MemberService.java
@@ -3,7 +3,6 @@ package com.zelusik.eatery.service;
 import com.zelusik.eatery.constant.FoodCategoryValue;
 import com.zelusik.eatery.constant.review.MemberDeletionSurveyType;
 import com.zelusik.eatery.domain.member.*;
-import com.zelusik.eatery.dto.ImageDto;
 import com.zelusik.eatery.dto.member.MemberDeletionSurveyDto;
 import com.zelusik.eatery.dto.member.MemberDto;
 import com.zelusik.eatery.dto.member.request.MemberUpdateRequest;
@@ -21,6 +20,7 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -133,8 +133,8 @@ public class MemberService {
     public MemberDto update(Long memberId, MemberUpdateRequest updateRequest) {
         Member member = findById(memberId);
 
-        ImageDto imageDtoForUpdate = updateRequest.getProfileImage();
-        if (imageDtoForUpdate == null) {
+        MultipartFile profileImageForUpdate = updateRequest.getProfileImage();
+        if (profileImageForUpdate == null) {
             member.update(
                     updateRequest.getNickname(),
                     updateRequest.getBirthDay(),
@@ -144,7 +144,7 @@ public class MemberService {
             Optional<ProfileImage> oldProfileImage = profileImageService.findByMember(member);
             oldProfileImage.ifPresent(profileImageService::softDelete);
 
-            ProfileImage profileImage = profileImageService.upload(member, imageDtoForUpdate);
+            ProfileImage profileImage = profileImageService.upload(member, profileImageForUpdate);
             member.update(
                     profileImage.getUrl(),
                     profileImage.getThumbnailUrl(),

--- a/src/main/java/com/zelusik/eatery/service/ProfileImageService.java
+++ b/src/main/java/com/zelusik/eatery/service/ProfileImageService.java
@@ -2,12 +2,11 @@ package com.zelusik.eatery.service;
 
 import com.zelusik.eatery.domain.member.Member;
 import com.zelusik.eatery.domain.member.ProfileImage;
-import com.zelusik.eatery.dto.ImageDto;
-import com.zelusik.eatery.dto.file.S3FileDto;
 import com.zelusik.eatery.repository.member.ProfileImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
@@ -24,21 +23,20 @@ public class ProfileImageService {
     /**
      * Member profile image entity를 생성하여 DB에 저장하고 S3에 upload한다.
      *
-     * @param member Member
-     * @param profileImage Profile image
+     * @param member                Member
+     * @param profileImageForUpdate Profile image
      * @return 생성된 ProfileImage entity
      */
     @Transactional
-    public ProfileImage upload(Member member, ImageDto profileImage) {
-        S3FileDto image = fileService.uploadFile(profileImage.getImage(), DIR_PATH);
-        S3FileDto thumbnailImage = fileService.uploadFile(profileImage.getThumbnailImage(), DIR_PATH + "thumbnail/");
+    public ProfileImage upload(Member member, MultipartFile profileImageForUpdate) {
+        S3ImageDto imageDto = fileService.uploadImageWithResizing(profileImageForUpdate, DIR_PATH);
         return profileImageRepository.save(ProfileImage.of(
                 member,
-                image.getOriginalName(),
-                image.getStoredName(),
-                image.getUrl(),
-                thumbnailImage.getStoredName(),
-                thumbnailImage.getUrl()
+                imageDto.getOriginalName(),
+                imageDto.getStoredName(),
+                imageDto.getUrl(),
+                imageDto.getThumbnailStoredName(),
+                imageDto.getThumbnailUrl()
         ));
     }
 

--- a/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
@@ -133,12 +133,7 @@ class MemberControllerTest {
     void givenMemberUpdateInfoWithoutProfileImage_whenUpdatingMyInfo_thenUpdate() throws Exception {
         // given
         long memberId = 1L;
-        MemberUpdateRequest memberUpdateInfo = MemberUpdateRequest.of(
-                "update",
-                LocalDate.of(2020, 1, 1),
-                Gender.ETC,
-                null
-        );
+        MemberUpdateRequest memberUpdateInfo = new MemberUpdateRequest("update", LocalDate.of(2020, 1, 1), Gender.ETC, null);
         given(memberService.update(eq(memberId), any(MemberUpdateRequest.class)))
                 .willReturn(MemberTestUtils.createMemberDtoWithId(memberId));
 

--- a/src/test/java/com/zelusik/eatery/unit/service/MemberServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/MemberServiceTest.java
@@ -21,7 +21,6 @@ import com.zelusik.eatery.repository.member.TermsInfoRepository;
 import com.zelusik.eatery.service.MemberService;
 import com.zelusik.eatery.service.ProfileImageService;
 import com.zelusik.eatery.util.MemberTestUtils;
-import com.zelusik.eatery.util.MultipartFileTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +35,7 @@ import java.util.Optional;
 
 import static com.zelusik.eatery.constant.FoodCategoryValue.*;
 import static com.zelusik.eatery.util.MemberTestUtils.*;
+import static com.zelusik.eatery.util.MultipartFileTestUtils.createMockMultipartFile;
 import static com.zelusik.eatery.util.TermsInfoTestUtils.createTermsInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -169,12 +169,7 @@ class MemberServiceTest {
         // given
         long memberId = 1L;
         Member findMember = createMember(memberId);
-        MemberUpdateRequest memberUpdateInfo = MemberUpdateRequest.of(
-                "update",
-                LocalDate.of(2020, 1, 1),
-                Gender.ETC,
-                null
-        );
+        MemberUpdateRequest memberUpdateInfo = new MemberUpdateRequest("update", LocalDate.of(2020, 1, 1), Gender.ETC, null);
         given(memberRepository.findByIdAndDeletedAtNull(memberId)).willReturn(Optional.of(findMember));
 
         // when
@@ -193,16 +188,9 @@ class MemberServiceTest {
         // given
         long memberId = 1L;
         Member findMember = createMember(memberId);
-        MemberUpdateRequest memberUpdateInfo = MemberUpdateRequest.of(
-                "update",
-                LocalDate.of(2020, 1, 1),
-                Gender.ETC,
-                MultipartFileTestUtils.createMockImageDto()
-        );
-        given(memberRepository.findByIdAndDeletedAtNull(memberId))
-                .willReturn(Optional.of(findMember));
-        given(profileImageService.upload(any(Member.class), eq(memberUpdateInfo.getProfileImage())))
-                .willReturn(createProfileImage(10L));
+        MemberUpdateRequest memberUpdateInfo = new MemberUpdateRequest("update", LocalDate.of(2020, 1, 1), Gender.ETC, createMockMultipartFile());
+        given(memberRepository.findByIdAndDeletedAtNull(memberId)).willReturn(Optional.of(findMember));
+        given(profileImageService.upload(any(Member.class), eq(memberUpdateInfo.getProfileImage()))).willReturn(createProfileImage(10L));
 
         // when
         MemberDto updatedMemberDto = sut.update(memberId, memberUpdateInfo);


### PR DESCRIPTION
## 🔥 Related Issue
- Close #231 

## 🏃‍ Task
- 회원 정보 수정 시 프로필 사진에 대해 원본 이미지만을 받아 썸네일용으로 리사이징 후 저장하도록 리팩토링

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
