### PR TITLE
fix: #242 처음으로 장소 메뉴를 저장(초기화)했을 때 메뉴 정보가 없는 경우 빈 문자열이 담긴 리스트가 반환되는 문제 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/converter/PlaceMenusConverter.java
+++ b/src/main/java/com/zelusik/eatery/converter/PlaceMenusConverter.java
@@ -1,5 +1,7 @@
 package com.zelusik.eatery.converter;
 
+import org.springframework.lang.Nullable;
+
 import javax.persistence.AttributeConverter;
 import java.util.Arrays;
 import java.util.List;
@@ -9,12 +11,18 @@ public class PlaceMenusConverter implements AttributeConverter<List<String>, Str
     private static final String DELIMITER = ",";
 
     @Override
-    public String convertToDatabaseColumn(List<String> attribute) {
+    public String convertToDatabaseColumn(@Nullable List<String> attribute) {
+        if (attribute == null || attribute.size() == 0) {
+            return null;
+        }
         return String.join(DELIMITER, attribute);
     }
 
     @Override
-    public List<String> convertToEntityAttribute(String dbData) {
+    public List<String> convertToEntityAttribute(@Nullable String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return List.of();
+        }
         return Arrays.stream(dbData.split(DELIMITER)).toList();
     }
 }

--- a/src/main/java/com/zelusik/eatery/domain/place/PlaceMenus.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/PlaceMenus.java
@@ -27,7 +27,6 @@ public class PlaceMenus extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Place place;
 
-    @Column(nullable = false)
     @Convert(converter = PlaceMenusConverter.class)
     private List<String> menus;
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #242 

## 🏃‍ Task
- 메뉴 정보가 없는 경우, 빈 문자열이 담긴 리스트가 반환되지 않도록 converter 로직 수정
  - 메뉴 정보가 없는 경우 `null`이 저장되도록 구현
  - DB에 저장된 `menus`가 `null`인 경우 field 값으로 빈 리스트가 되도록 구현
- `place_menus.menus`의 not null 제약조건 해제

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
