### PR TITLE
하나의 장소에 대해 여러 개의 장소 메뉴 데이터가 생성되는 문제 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/PlaceMenusController.java
+++ b/src/main/java/com/zelusik/eatery/controller/PlaceMenusController.java
@@ -31,6 +31,10 @@ public class PlaceMenusController {
                     "<p>응답으로, DB에 저장된 메뉴들의 목록을 반환한다.",
             security = @SecurityRequirement(name = "access-token")
     )
+    @ApiResponses({
+            @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = PlaceMenusResponse.class))),
+            @ApiResponse(description = "[3005] 메뉴 목록 데이터가 이미 존재하는 경우.", responseCode = "409", content = @Content)
+    })
     @PostMapping("/places/{placeId}/menus")
     public ResponseEntity<PlaceMenusResponse> savePlaceMenus(@Parameter(description = "PK of place", example = "3") @PathVariable Long placeId) {
         PlaceMenusDto result = placeMenusService.savePlaceMenus(placeId);

--- a/src/main/java/com/zelusik/eatery/domain/place/PlaceMenus.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/PlaceMenus.java
@@ -23,7 +23,7 @@ public class PlaceMenus extends BaseEntity {
     @Column(name = "place_menus_id")
     private Long id;
 
-    @JoinColumn(name = "place_id", nullable = false)
+    @JoinColumn(name = "place_id", nullable = false, unique = true)
     @OneToOne(fetch = FetchType.LAZY)
     private Place place;
 

--- a/src/main/java/com/zelusik/eatery/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/exception/ExceptionType.java
@@ -134,6 +134,7 @@ public enum ExceptionType {
     NOT_ACCEPTABLE_PLACE_SEARCH_KEYWORD(3002, "유효하지 않은 검색 키워드입니다.", NotAcceptablePlaceSearchKeyword.class),
     NOT_ACCEPTABLE_FOOD_CATEGORY(3003, "유효하지 않은 음식 카테고리입니다.", NotAcceptableFoodCategory.class),
     PLACE_MENUS_NOT_FOUND(3004, "일치하는 장소의 메뉴 데이터를 찾을 수 없습니다.", PlaceMenusNotFoundException.class),
+    PLACE_MENUS_ALREADY_EXISTS(3005, "장소의 메뉴 데이터가 이미 존재합니다. 추가로 데이터를 생성/저장할 수 없습니다.", PlaceMenusAlreadyExistsException.class),
 
     /**
      * 리뷰({@link Review}) 관련 예외

--- a/src/main/java/com/zelusik/eatery/exception/place/PlaceMenusAlreadyExistsException.java
+++ b/src/main/java/com/zelusik/eatery/exception/place/PlaceMenusAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.zelusik.eatery.exception.place;
+
+import com.zelusik.eatery.exception.common.ConflictException;
+
+public class PlaceMenusAlreadyExistsException extends ConflictException {
+
+    public PlaceMenusAlreadyExistsException(Long placeId) {
+        super("placeId=" + placeId);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceMenusRepository.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceMenusRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface PlaceMenusRepository extends JpaRepository<PlaceMenus, Long> {
 
+    boolean existsByPlace_Id(Long placeId);
+
     Optional<PlaceMenus> findByPlace_Id(Long placeId);
 
     @EntityGraph(attributePaths = "place")

--- a/src/main/java/com/zelusik/eatery/service/PlaceMenusService.java
+++ b/src/main/java/com/zelusik/eatery/service/PlaceMenusService.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.service;
 import com.zelusik.eatery.domain.place.Place;
 import com.zelusik.eatery.domain.place.PlaceMenus;
 import com.zelusik.eatery.dto.place.PlaceMenusDto;
+import com.zelusik.eatery.exception.place.PlaceMenusAlreadyExistsException;
 import com.zelusik.eatery.exception.place.PlaceMenusNotFoundException;
 import com.zelusik.eatery.repository.place.PlaceMenusRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,10 @@ public class PlaceMenusService {
     @NonNull
     @Transactional
     public PlaceMenusDto savePlaceMenus(@NonNull Long placeId) {
+        if (placeMenusRepository.existsByPlace_Id(placeId)) {
+            throw new PlaceMenusAlreadyExistsException(placeId);
+        }
+
         Place place = placeService.findById(placeId);
         List<String> extractedMenus = webScrapingService.scrapMenuList(place.getKakaoPid());
         PlaceMenus placeMenus = placeMenusRepository.save(PlaceMenus.of(place, extractedMenus));


### PR DESCRIPTION
## 🔥 Related Issue
- Close #244 

## 🏃‍ Task
- 장소 메뉴(`PlaceMenus`의 FK에 unique 제약조건 추가
- 장소 메뉴 데이터 중복 저장 시 예외가 발생하도록 business logic 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
