### PR TITLE
장소 메뉴 목록 업데이트 시, 전달받은 메뉴 목록에 중복된 메뉴가 있는 경우 예외가 발생하도록 business logic 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/PlaceMenusController.java
+++ b/src/main/java/com/zelusik/eatery/controller/PlaceMenusController.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
 import java.net.URI;
 
 @Tag(name = "장소 메뉴 관련 API")
@@ -77,6 +76,10 @@ public class PlaceMenusController {
                     "<p>전달받은 데이터가 추가되는 것이 아닌, 기존 데이터가 덮어씌워지는 것(overwrite)이므로 주의해야 한다.",
             security = @SecurityRequirement(name = "access-token")
     )
+    @ApiResponses({
+            @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = PlaceMenusResponse.class))),
+            @ApiResponse(description = "[3006] 전달받은 메뉴 목록에 중복된 메뉴가 존재하는 경우", responseCode = "400", content = @Content)
+    })
     @PutMapping("/places/{placeId}/menus")
     public PlaceMenusResponse updatePlaceMenus(
             @Parameter(description = "PK of place", example = "3") @PathVariable Long placeId,

--- a/src/main/java/com/zelusik/eatery/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/exception/ExceptionType.java
@@ -1,11 +1,11 @@
 package com.zelusik.eatery.exception;
 
+import com.zelusik.eatery.constant.exception.ValidationErrorCode;
 import com.zelusik.eatery.domain.Bookmark;
 import com.zelusik.eatery.domain.curation.Curation;
 import com.zelusik.eatery.domain.member.Member;
 import com.zelusik.eatery.domain.place.Place;
 import com.zelusik.eatery.domain.review.Review;
-import com.zelusik.eatery.constant.exception.ValidationErrorCode;
 import com.zelusik.eatery.exception.auth.AccessTokenValidateException;
 import com.zelusik.eatery.exception.auth.AppleOAuthLoginException;
 import com.zelusik.eatery.exception.auth.RefreshTokenValidateException;
@@ -16,6 +16,7 @@ import com.zelusik.eatery.exception.curation.CurationNotFoundException;
 import com.zelusik.eatery.exception.file.MultipartFileNotReadableException;
 import com.zelusik.eatery.exception.kakao.KakaoTokenValidateException;
 import com.zelusik.eatery.exception.member.MemberIdNotFoundException;
+import com.zelusik.eatery.exception.member.ProfileImageNotFoundException;
 import com.zelusik.eatery.exception.place.*;
 import com.zelusik.eatery.exception.review.NotAcceptableReviewKeyword;
 import com.zelusik.eatery.exception.review.ReviewDeletePermissionDeniedException;
@@ -23,7 +24,6 @@ import com.zelusik.eatery.exception.review.ReviewNotFoundException;
 import com.zelusik.eatery.exception.review.ReviewUpdatePermissionDeniedException;
 import com.zelusik.eatery.exception.scraping.OpeningHoursUnexpectedFormatException;
 import com.zelusik.eatery.exception.scraping.ScrapingServerInternalError;
-import com.zelusik.eatery.exception.member.ProfileImageNotFoundException;
 import com.zelusik.eatery.log.LogUtils;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -135,6 +135,7 @@ public enum ExceptionType {
     NOT_ACCEPTABLE_FOOD_CATEGORY(3003, "유효하지 않은 음식 카테고리입니다.", NotAcceptableFoodCategory.class),
     PLACE_MENUS_NOT_FOUND(3004, "일치하는 장소의 메뉴 데이터를 찾을 수 없습니다.", PlaceMenusNotFoundException.class),
     PLACE_MENUS_ALREADY_EXISTS(3005, "장소의 메뉴 데이터가 이미 존재합니다. 추가로 데이터를 생성/저장할 수 없습니다.", PlaceMenusAlreadyExistsException.class),
+    CONTAINS_DUPLICATE_MENUS(3006, "전달받은 메뉴 목록에 중복된 메뉴가 존재합니다.", ContainsDuplicateMenusException.class),
 
     /**
      * 리뷰({@link Review}) 관련 예외

--- a/src/main/java/com/zelusik/eatery/exception/place/ContainsDuplicateMenusException.java
+++ b/src/main/java/com/zelusik/eatery/exception/place/ContainsDuplicateMenusException.java
@@ -1,0 +1,11 @@
+package com.zelusik.eatery.exception.place;
+
+import com.zelusik.eatery.exception.common.BadRequestException;
+
+import java.util.List;
+
+public class ContainsDuplicateMenusException extends BadRequestException {
+    public ContainsDuplicateMenusException(List<String> menus) {
+        super("전달받은 메뉴 목록=" + menus);
+    }
+}

--- a/src/test/java/com/zelusik/eatery/unit/service/PlaceMenusServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/PlaceMenusServiceTest.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.unit.service;
 import com.zelusik.eatery.domain.place.Place;
 import com.zelusik.eatery.domain.place.PlaceMenus;
 import com.zelusik.eatery.dto.place.PlaceMenusDto;
+import com.zelusik.eatery.exception.place.ContainsDuplicateMenusException;
 import com.zelusik.eatery.exception.place.PlaceMenusAlreadyExistsException;
 import com.zelusik.eatery.exception.place.PlaceMenusNotFoundException;
 import com.zelusik.eatery.repository.place.PlaceMenusRepository;
@@ -201,6 +202,27 @@ class PlaceMenusServiceTest {
                 .hasFieldOrPropertyWithValue("id", placeMenusId)
                 .hasFieldOrPropertyWithValue("placeId", placeId)
                 .hasFieldOrPropertyWithValue("menus", menusForUpdate);
+    }
+
+    @DisplayName("중복된 메뉴가 존재하는 메뉴 목록이 주어지고, 메뉴 목록을 업데이트하면, 예외가 발생한다.")
+    @Test
+    void givenMenusWhereDuplicateMenusExist_whenUpdateMenus_thenThrowContainsDuplicateMenusException() {
+        // given
+        long placeId = 1L;
+        List<String> menusForUpdate = List.of("양념치킨", "양념 치킨");
+
+        // when
+        Throwable t = catchThrowable(() -> sut.updateMenus(placeId, menusForUpdate));
+
+        // then
+        verifyEveryMocksShouldHaveNoInteractions();
+        assertThat(t).isInstanceOf(ContainsDuplicateMenusException.class);
+    }
+
+    private void verifyEveryMocksShouldHaveNoInteractions() {
+        then(placeService).shouldHaveNoInteractions();
+        then(webScrapingService).shouldHaveNoInteractions();
+        then(placeMenusRepository).shouldHaveNoInteractions();
     }
 
     private void verifyEveryMocksShouldHaveNoMoreInteractions() {


### PR DESCRIPTION
## 🔥 Related Issue
- #237

## 🏃‍ Task
- 장소 메뉴 목록 업데이트 시, 전달받은 메뉴 목록에 중복된 메뉴가 있는 경우 예외가 발생하도록 business logic 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
