### PR TITLE
#260 장소 저장 API(`POST /api/places`) 호출 시 NPE가 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/converter/ReviewKeywordValueConverter.java
+++ b/src/main/java/com/zelusik/eatery/converter/ReviewKeywordValueConverter.java
@@ -14,7 +14,7 @@ public class ReviewKeywordValueConverter implements AttributeConverter<List<Revi
     @Override
     public String convertToDatabaseColumn(List<ReviewKeywordValue> attribute) {
         if (attribute == null || attribute.size() == 0) {
-            return null;
+            return "";
         }
 
         return attribute.stream()

--- a/src/main/java/com/zelusik/eatery/domain/place/Address.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/Address.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.Column;
@@ -18,17 +20,21 @@ import java.util.Objects;
 public class Address {
 
     @Schema(description = "시/도", example = "서울")
+    @NonNull
     @Column(nullable = false)
     private String sido;
 
     @Schema(description = "시/군/구", example = "마포구")
+    @NonNull
     @Column(nullable = false)
     private String sgg;
 
     @Schema(description = "지번주소", example = "연남동 568-26")
+    @Nullable
     private String lotNumberAddress;
 
     @Schema(description = "도로명주소", example = "월드컵북로6길 61")
+    @Nullable
     private String roadAddress;
 
     public Address(String lotNumberAddress, String roadAddress) {

--- a/src/main/java/com/zelusik/eatery/domain/place/Place.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/Place.java
@@ -26,6 +26,7 @@ public class Place extends BaseTimeEntity {
     private Long id;
 
     @Setter
+    @Column(nullable = false)
     @Convert(converter = ReviewKeywordValueConverter.class)
     private List<ReviewKeywordValue> top3Keywords;
 

--- a/src/main/java/com/zelusik/eatery/domain/place/Place.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/Place.java
@@ -4,7 +4,12 @@ import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.converter.ReviewKeywordValueConverter;
 import com.zelusik.eatery.domain.BaseTimeEntity;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -61,31 +66,41 @@ public class Place extends BaseTimeEntity {
     @OneToMany(mappedBy = "place")
     private List<OpeningHours> openingHoursList = new LinkedList<>();
 
-    public static Place of(String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours) {
-        return of(null, null, kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, null, null);
+    public static Place of(
+            @NonNull String kakaoPid,
+            @NonNull String name,
+            @NonNull String pageUrl,
+            @NonNull KakaoCategoryGroupCode categoryGroupCode,
+            @NonNull PlaceCategory category,
+            @Nullable String phone,
+            @NonNull Address address,
+            @Nullable String homepageUrl,
+            @NonNull Point point,
+            @Nullable String closingHours
+    ) {
+        return of(null, List.of(), kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, null, null);
     }
 
-    public static Place of(Long id, List<ReviewKeywordValue> top3Keywords, String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        return Place.builder()
-                .id(id)
-                .top3Keywords(top3Keywords)
-                .kakaoPid(kakaoPid)
-                .name(name)
-                .pageUrl(pageUrl)
-                .categoryGroupCode(categoryGroupCode)
-                .category(category)
-                .phone(phone)
-                .address(address)
-                .homepageUrl(homepageUrl)
-                .point(point)
-                .closingHours(closingHours)
-                .createdAt(createdAt)
-                .updatedAt(updatedAt)
-                .build();
+    public static Place of(
+            @Nullable Long id,
+            @NonNull List<ReviewKeywordValue> top3Keywords,
+            @NonNull String kakaoPid,
+            @NonNull String name,
+            @NonNull String pageUrl,
+            @NonNull KakaoCategoryGroupCode categoryGroupCode,
+            @NonNull PlaceCategory category,
+            @Nullable String phone,
+            @NonNull Address address,
+            @Nullable String homepageUrl,
+            @NonNull Point point,
+            @Nullable String closingHours,
+            @Nullable LocalDateTime createdAt,
+            @Nullable LocalDateTime updatedAt
+    ) {
+        return new Place(id, top3Keywords, kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, createdAt, updatedAt);
     }
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private Place(Long id, List<ReviewKeywordValue> top3Keywords, String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Place(@Nullable Long id, @NonNull List<ReviewKeywordValue> top3Keywords, @NonNull String kakaoPid, @NonNull String name, @NonNull String pageUrl, @NonNull KakaoCategoryGroupCode categoryGroupCode, @NonNull PlaceCategory category, @Nullable String phone, @NonNull Address address, @Nullable String homepageUrl, @NonNull Point point, @Nullable String closingHours, @Nullable LocalDateTime createdAt, @Nullable LocalDateTime updatedAt) {
         super(createdAt, updatedAt);
         this.id = id;
         this.top3Keywords = top3Keywords;

--- a/src/main/java/com/zelusik/eatery/domain/place/PlaceCategory.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/PlaceCategory.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -17,20 +19,23 @@ import java.util.Objects;
 public class PlaceCategory {
 
     @Schema(description = "카테고리 1", example = "퓨전요리")
+    @NonNull
     @Column(nullable = false)
     private String firstCategory;
 
     @Schema(description = "카테고리 2", example = "퓨전일식")
+    @Nullable
     private String secondCategory;
 
     @Schema(description = "카테고리 3")
+    @Nullable
     private String thirdCategory;
 
     public static PlaceCategory of(String categoryName) {
         String[] categories = categoryName.split(" > ");
         int length = categories.length;
 
-        String firstCategory = length > 1 ? categories[1] : null;
+        String firstCategory = length > 1 ? categories[1] : "";
         String secondCategory = length > 2 ? categories[2] : null;
         String thirdCategory = length > 3 ? categories[3] : null;
 

--- a/src/main/java/com/zelusik/eatery/dto/place/PlaceDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/place/PlaceDto.java
@@ -21,22 +21,44 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class PlaceDto {
+
     private Long id;
+
     private List<ReviewKeywordValue> top3Keywords;
+
     private String kakaoPid;
+
     private String name;
+
     private String pageUrl;
+
     private KakaoCategoryGroupCode categoryGroupCode;
+
     private PlaceCategory category;
+
+    @Nullable
     private String phone;
+
     private Address address;
+
+    @Nullable
     private String homepageUrl;
+
     private Point point;
+
+    @Nullable
     private String closingHours;
+
     private List<OpeningHoursDto> openingHoursDtos;
+
+    @Nullable
     private List<ReviewImageDto> images;
+
+    @Nullable
     private Boolean isMarked;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
 
     @NonNull

--- a/src/test/java/com/zelusik/eatery/util/ReviewKeywordValueConverterTest.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewKeywordValueConverterTest.java
@@ -59,8 +59,8 @@ class ReviewKeywordValueConverterTest {
 
     static Stream<Arguments> keywordList() {
         return Stream.of(
-                arguments(null, null),
-                arguments(List.of(), null),
+                arguments(null, ""),
+                arguments(List.of(), ""),
                 arguments(List.of(FRESH), "FRESH"),
                 arguments(List.of(FRESH, BEST_FLAVOR), "FRESH BEST_FLAVOR"),
                 arguments(List.of(FRESH, BEST_FLAVOR, BEST_MENU_COMBINATION), "FRESH BEST_FLAVOR BEST_MENU_COMBINATION"),


### PR DESCRIPTION
## 🔥 Related Issue
- Close #260 

## 🏃‍ Task
- `Place`의 `top3Keywords` column에 not null 제약조건 설정
- `Place`의 생성 method에 대해 `top3Keywords`에 `null`이 들어가지 않도록 수정

문제를 살펴보니 문제가 되는 코드는 다음과 같았다.
```java
// PlaceService
Place savedPlace = placeRepository.save(placeCreateRequest.toDto(scrapingInfo.getHomepageUrl(), scrapingInfo.getClosingHours()).toEntity());
```
`CrudReposiotry.save()`의 응답 데이터에 대해 `ReviewKeywordValueConverter`가 동작하지 않고 있었고, 그 때문에 `top3Keywords`에 `null`이 들어가 `PlaceResponse`가 생성되지 않는 것이었다.

## 📄 Reference
- [@Convert is not getting called for the respository.save](https://stackoverflow.com/questions/61681332/convert-is-not-getting-called-for-the-respository-save)

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
