### PR TITLE
feat: #264 리뷰 생성 시 메뉴 태그 정보도 받을 수 있도록 dto 및 business logic 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/ReviewController.java
+++ b/src/main/java/com/zelusik/eatery/controller/ReviewController.java
@@ -53,8 +53,7 @@ public class ReviewController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @ParameterObject @Valid @ModelAttribute ReviewCreateRequest request
     ) {
-        ReviewResponse response = ReviewResponse.from(reviewService.create(userPrincipal.getMemberId(), request, request.getImages()));
-
+        ReviewResponse response = ReviewResponse.from(reviewService.create(userPrincipal.getMemberId(), request));
         return ResponseEntity
                 .created(URI.create("/api/reviews/" + response.getId()))
                 .body(response);
@@ -112,6 +111,7 @@ public class ReviewController {
                         .map(FeedResponse::from));
     }
 
+    // TODO: 메뉴 태그 정보가 담긴 ReviewResponse를 응답 객체로 사용할 것인지 검토 필요
     @Operation(
             summary = "내가 작성한 리뷰 조회",
             description = "<p>내가 작성한 리뷰를 최신순으로 조회합니다.",

--- a/src/main/java/com/zelusik/eatery/domain/review/MenuTagPoint.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/MenuTagPoint.java
@@ -1,29 +1,27 @@
 package com.zelusik.eatery.domain.review;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.lang.NonNull;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter // for @ModelAttribute
 @Getter
 @Embeddable
 public class MenuTagPoint {
 
     @Schema(description = "메뉴 태그의 x좌표", example = "30.45")
-    @NonNull
+    @NotNull
     @Column(nullable = false)
     private Double x;
 
     @Schema(description = "메뉴 태그의 y좌표", example = "12.7504")
-    @NonNull
+    @NotNull
     @Column(nullable = false)
     private Double y;
 

--- a/src/main/java/com/zelusik/eatery/dto/review/ReviewImageDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/ReviewImageDto.java
@@ -4,6 +4,7 @@ import com.zelusik.eatery.domain.review.ReviewImage;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.lang.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,17 +14,28 @@ import java.util.List;
 public class ReviewImageDto {
 
     private Long id;
-    private Long reviewId;
-    private String originalName;
-    private String storedName;
-    private String url;
-    private String thumbnailStoredName;
-    private String thumbnailUrl;
-    private List<ReviewImageMenuTagDto> menuTags;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-    private LocalDateTime deletedAt;
 
+    private Long reviewId;
+
+    private String originalName;
+
+    private String storedName;
+
+    private String url;
+
+    private String thumbnailStoredName;
+
+    private String thumbnailUrl;
+
+    @Nullable
+    private List<ReviewImageMenuTagDto> menuTags;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+    
     public static ReviewImageDto of(Long id, Long reviewId, String originalName, String storedName, String url, String thumbnailStoredName, String thumbnailUrl, List<ReviewImageMenuTagDto> menuTags, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         return new ReviewImageDto(id, reviewId, originalName, storedName, url, thumbnailStoredName, thumbnailUrl, menuTags, createdAt, updatedAt, deletedAt);
     }

--- a/src/main/java/com/zelusik/eatery/dto/review/ReviewImageMenuTagDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/ReviewImageMenuTagDto.java
@@ -1,11 +1,13 @@
 package com.zelusik.eatery.dto.review;
 
 import com.zelusik.eatery.domain.review.MenuTagPoint;
+import com.zelusik.eatery.domain.review.ReviewImage;
 import com.zelusik.eatery.domain.review.ReviewImageMenuTag;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,17 +19,19 @@ public class ReviewImageMenuTagDto {
     private String content;
     private MenuTagPoint point;
 
+    public static ReviewImageMenuTagDto of(@NonNull String content, @NonNull MenuTagPoint point) {
+        return new ReviewImageMenuTagDto(null, null, content, point);
+    }
+
     public static ReviewImageMenuTagDto of(Long id, Long reviewImageId, String content, MenuTagPoint point) {
         return new ReviewImageMenuTagDto(id, reviewImageId, content, point);
     }
 
-    // TODO: 이 시점에서 ReviewImageMenuTag.reviewImage의 lazy loading이 될 수 있으므로 고려한 코드 작성 필요
     public static ReviewImageMenuTagDto from(ReviewImageMenuTag entity) {
         return of(entity.getId(), entity.getReviewImage().getId(), entity.getContent(), entity.getPoint());
     }
 
-    // ReviewImage를 DB에서 실제 조회(lazy loading)하지 않고 ReviewImageMenuTag를 생성하기 위한 reviewImageId를 따로 전달받는다.
-    public static ReviewImageMenuTagDto from(ReviewImageMenuTag entity, Long reviewImageId) {
-        return of(entity.getId(), reviewImageId, entity.getContent(), entity.getPoint());
+    public ReviewImageMenuTag toEntity(@NonNull ReviewImage reviewImage) {
+        return ReviewImageMenuTag.of(reviewImage, getContent(), getPoint());
     }
 }

--- a/src/main/java/com/zelusik/eatery/dto/review/request/ReviewCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/request/ReviewCreateRequest.java
@@ -6,6 +6,7 @@ import com.zelusik.eatery.dto.place.request.PlaceCreateRequest;
 import com.zelusik.eatery.dto.review.ReviewDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Setter
+@Setter // for @ModelAttribute
 @Getter
 public class ReviewCreateRequest {
 
@@ -31,13 +32,50 @@ public class ReviewCreateRequest {
     private String content;
 
     @Schema(description = """
-            <p>업로드할 이미지 파일들
-            <p>요청 데이터 예시는 다음과 같습니다.
+            <p>업로드할 이미지 파일들</p>
+                        
+            <p>이미지 객체는 다음 두 개의 field로 구성됩니다.</p>
             <ul>
-                <li><code>images[0].image = 이미지1</code></li>
-                <li><code>images[1].image = 이미지2</code></li>
+                <li><code>image</code>: 이미지 파일</li>
+                <li><code>menuTags</code>: 메뉴 태그 목록 (array)</li>
             </ul>
+                        
+            <p>메뉴 태그 객체(menuTags)는 다음 두 개의 field로 구성됩니다.</p>
+            <ul>
+                <li><code>content</code>: 메뉴 태그 내용(메뉴 이름)</li>
+                <li><code>point</code>: 메뉴 태그 좌표 정보</li>
+            </ul>
+                        
+            <p>메뉴 태그 객체(point)는 다음 두 개의 field로 구성됩니다.</p>
+            <ul>
+                <li><code>x</code>: 메뉴 태그의 x좌표(double)</li>
+                <li><code>y</code>: 메뉴 태그의 y좌표(double)</li>
+            </ul>
+                        
+            <p>요청 데이터 예시를 JSON 형식으로 표현하면 다음과 같습니다.</p>
+            <pre>
+            {
+                "image": "이미지 파일",
+                "menuTags": [
+                    {
+                        "content": "치킨",
+                        "point": {
+                            "x": 10.25,
+                            "y": 45.05
+                        }
+                    },
+                    {
+                        "content": "피자",
+                        "point": {
+                            "x": 10.25,
+                            "y": 45.05
+                        }
+                    }
+                ]
+            }
+            </pre>
             """)
+    @NonNull
     private List<ReviewImageCreateRequest> images;
 
     public static ReviewCreateRequest of(PlaceCreateRequest place, List<String> keywords, String autoCreatedContent, String content, List<ReviewImageCreateRequest> images) {

--- a/src/main/java/com/zelusik/eatery/dto/review/request/ReviewImageCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/request/ReviewImageCreateRequest.java
@@ -2,17 +2,22 @@ package com.zelusik.eatery.dto.review.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Setter
+@Setter // for @ModelAttribute
 @Getter
 public class ReviewImageCreateRequest {
 
-    @Schema(description = "이미지")
+    @Schema(description = "리뷰 이미지")
     @NotNull
     private MultipartFile image;
+
+    @Nullable
+    private List<ReviewMenuTagCreateRequest> menuTags;
 }

--- a/src/main/java/com/zelusik/eatery/dto/review/request/ReviewMenuTagCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/request/ReviewMenuTagCreateRequest.java
@@ -1,0 +1,27 @@
+package com.zelusik.eatery.dto.review.request;
+
+import com.zelusik.eatery.domain.review.MenuTagPoint;
+import com.zelusik.eatery.dto.review.ReviewImageMenuTagDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter // for @ModelAttribute
+@Getter
+public class ReviewMenuTagCreateRequest {
+
+    @Schema(description = "메뉴 태그 내용", example = "페퍼로니 피자")
+    @NotBlank
+    private String content;
+
+    @NotNull
+    private MenuTagPoint point;
+
+    public ReviewImageMenuTagDto toDto() {
+        return ReviewImageMenuTagDto.of(getContent(), getPoint());
+    }
+}

--- a/src/main/java/com/zelusik/eatery/dto/review/response/ReviewImageResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/response/ReviewImageResponse.java
@@ -6,8 +6,10 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -27,9 +29,11 @@ public class ReviewImageResponse {
         return new ReviewImageResponse(
                 dto.getUrl(),
                 dto.getThumbnailUrl(),
-                dto.getMenuTags().stream()
-                        .map(ReviewImageMenuTagResponse::from)
-                        .toList()
+                Optional.ofNullable(dto.getMenuTags())
+                        .map(menuTags -> menuTags.stream()
+                                .map(ReviewImageMenuTagResponse::from)
+                                .toList())
+                        .orElse(List.of())
         );
     }
 }

--- a/src/main/java/com/zelusik/eatery/dto/review/response/ReviewResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/response/ReviewResponse.java
@@ -1,7 +1,6 @@
 package com.zelusik.eatery.dto.review.response;
 
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
-import com.zelusik.eatery.dto.file.response.ImageResponse;
 import com.zelusik.eatery.dto.member.response.MemberResponse;
 import com.zelusik.eatery.dto.place.response.PlaceResponse;
 import com.zelusik.eatery.dto.review.ReviewDto;
@@ -31,10 +30,10 @@ public class ReviewResponse {
     @Schema(description = "내용", example = "미래에 제가 살 곳은 여기로 정했습니다. 고기를 주문하면 ...")
     private String content;
 
-    @Schema(description = "리뷰에 첨부된 이미지 파일 목록", example = "[\"https://eatery-s3-bucket.s3.ap-northeast-2.amazonaws.com/review/0950af0e-3950-4596-bba2-4fee11e4938a.jpg\"]")
-    private List<ImageResponse> images;
+    @Schema(description = "리뷰에 첨부된 이미지 파일 목록")
+    private List<ReviewImageResponse> images;
 
-    public static ReviewResponse of(Long id, MemberResponse writer, PlaceResponse place, List<String> keywords, String content, List<ImageResponse> images) {
+    public static ReviewResponse of(Long id, MemberResponse writer, PlaceResponse place, List<String> keywords, String content, List<ReviewImageResponse> images) {
         return new ReviewResponse(id, writer, place, keywords, content, images);
     }
 
@@ -48,7 +47,7 @@ public class ReviewResponse {
                         .toList(),
                 reviewDto.getContent(),
                 reviewDto.getReviewImageDtos().stream()
-                        .map(ImageResponse::from)
+                        .map(ReviewImageResponse::from)
                         .toList()
         );
     }

--- a/src/main/java/com/zelusik/eatery/service/ReviewImageService.java
+++ b/src/main/java/com/zelusik/eatery/service/ReviewImageService.java
@@ -29,10 +29,10 @@ public class ReviewImageService {
      * @param images 업로드할 이미지들
      */
     @Transactional
-    public void upload(Review review, List<ReviewImageCreateRequest> images) {
-        images.forEach(image -> {
+    public List<ReviewImage> upload(Review review, List<ReviewImageCreateRequest> images) {
+        List<ReviewImage> reviewImages = images.stream().map(image -> {
             S3ImageDto imageDto = fileService.uploadImageWithResizing(image.getImage(), DIR_PATH);
-            ReviewImage reviewImage = ReviewImage.of(
+            return ReviewImage.of(
                     review,
                     imageDto.getOriginalName(),
                     imageDto.getStoredName(),
@@ -40,9 +40,8 @@ public class ReviewImageService {
                     imageDto.getThumbnailStoredName(),
                     imageDto.getThumbnailUrl()
             );
-            review.getReviewImages().add(reviewImage);
-        });
-        reviewImageRepository.saveAll(review.getReviewImages());
+        }).toList();
+        return reviewImageRepository.saveAll(reviewImages);
     }
 
     public List<ReviewImageDto> findLatest3ByPlace(Long placeId) {

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -50,8 +50,7 @@ class ReviewControllerTest {
     @Test
     void givenReviewInfo_whenReviewCreate_thenReturnSavedReview() throws Exception {
         // given
-        given(reviewService.create(any(), any(ReviewCreateRequest.class), any()))
-                .willReturn(ReviewTestUtils.createReviewDto());
+        given(reviewService.create(any(), any(ReviewCreateRequest.class))).willReturn(ReviewTestUtils.createReviewDto());
 
         // when & then
         ReviewCreateRequest reviewCreateRequest = ReviewTestUtils.createReviewCreateRequest();

--- a/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.util;
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.member.Member;
 import com.zelusik.eatery.domain.place.Place;
+import com.zelusik.eatery.domain.review.MenuTagPoint;
 import com.zelusik.eatery.domain.review.Review;
 import com.zelusik.eatery.domain.review.ReviewImage;
 import com.zelusik.eatery.domain.review.ReviewKeyword;
@@ -10,6 +11,7 @@ import com.zelusik.eatery.dto.review.ReviewDto;
 import com.zelusik.eatery.dto.review.ReviewImageDto;
 import com.zelusik.eatery.dto.review.request.ReviewCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewImageCreateRequest;
+import com.zelusik.eatery.dto.review.request.ReviewMenuTagCreateRequest;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDateTime;
@@ -29,7 +31,13 @@ public class ReviewTestUtils {
 
     @NotNull
     public static ReviewImageCreateRequest createReviewImageCreateRequest() {
-        return new ReviewImageCreateRequest(MultipartFileTestUtils.createMockMultipartFile());
+        return new ReviewImageCreateRequest(
+                MultipartFileTestUtils.createMockMultipartFile(),
+                List.of(
+                        createReviewMenuTagCreateRequest("치킨"),
+                        createReviewMenuTagCreateRequest("피자")
+                )
+        );
     }
 
     public static ReviewDto createReviewDto() {
@@ -172,5 +180,9 @@ public class ReviewTestUtils {
                 LocalDateTime.now(),
                 null
         );
+    }
+
+    public static ReviewMenuTagCreateRequest createReviewMenuTagCreateRequest(String content) {
+        return new ReviewMenuTagCreateRequest(content, new MenuTagPoint(10.0, 50.0));
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #265 

## 🏃‍ Task
-  리뷰 생성과 관련한 dto(특히 request dto)들에 메뉴 태그 추가
- 리뷰 생성 로직에 메뉴 태그 저장과 관련된 business logic 추가

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
