### PR TITLE
리뷰 생성 시 전달받는 요청 데이터 중 "메뉴 태그의 좌표 값"의 data type을 `double`에서 `String`으로 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/review/MenuTagPoint.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/MenuTagPoint.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Setter // for @ModelAttribute
 @Getter
 @Embeddable
 public class MenuTagPoint {

--- a/src/main/java/com/zelusik/eatery/dto/review/request/MenuTagPointCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/request/MenuTagPointCreateRequest.java
@@ -1,0 +1,24 @@
+package com.zelusik.eatery.dto.review.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.persistence.Column;
+import javax.validation.constraints.NotBlank;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter // for @ModelAttribute
+@Getter
+public class MenuTagPointCreateRequest {
+
+    @Schema(description = "메뉴 태그의 x좌표", example = "30.45")
+    @NotBlank
+    @Column(nullable = false)
+    private String x;
+
+    @Schema(description = "메뉴 태그의 y좌표", example = "12.7504")
+    @NotBlank
+    @Column(nullable = false)
+    private String y;
+}

--- a/src/main/java/com/zelusik/eatery/dto/review/request/ReviewMenuTagCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/request/ReviewMenuTagCreateRequest.java
@@ -19,9 +19,15 @@ public class ReviewMenuTagCreateRequest {
     private String content;
 
     @NotNull
-    private MenuTagPoint point;
+    private MenuTagPointCreateRequest point;
 
     public ReviewImageMenuTagDto toDto() {
-        return ReviewImageMenuTagDto.of(getContent(), getPoint());
+        return ReviewImageMenuTagDto.of(
+                getContent(),
+                new MenuTagPoint(
+                        Double.parseDouble(point.getX()),
+                        Double.parseDouble(point.getY())
+                )
+        );
     }
 }

--- a/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
@@ -9,6 +9,7 @@ import com.zelusik.eatery.domain.review.ReviewImage;
 import com.zelusik.eatery.domain.review.ReviewKeyword;
 import com.zelusik.eatery.dto.review.ReviewDto;
 import com.zelusik.eatery.dto.review.ReviewImageDto;
+import com.zelusik.eatery.dto.review.request.MenuTagPointCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewImageCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewMenuTagCreateRequest;
@@ -183,6 +184,6 @@ public class ReviewTestUtils {
     }
 
     public static ReviewMenuTagCreateRequest createReviewMenuTagCreateRequest(String content) {
-        return new ReviewMenuTagCreateRequest(content, new MenuTagPoint(10.0, 50.0));
+        return new ReviewMenuTagCreateRequest(content, new MenuTagPointCreateRequest("10.0", "50.0"));
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #269 

## 🏃‍ Task
- 리뷰 생성 시 전달받는 요청 데이터 중 "메뉴 태그의 좌표 값"의 data type을 `double`에서 `String`으로 변경

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
