### PR TITLE
리뷰 생성 시 장소(`Place`) entity를 생성 및 저장하지 않도록 리팩토링

### DIFF
--- a/src/main/java/com/zelusik/eatery/dto/review/request/ReviewCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/request/ReviewCreateRequest.java
@@ -2,11 +2,9 @@ package com.zelusik.eatery.dto.review.request;
 
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.dto.place.PlaceDto;
-import com.zelusik.eatery.dto.place.request.PlaceCreateRequest;
 import com.zelusik.eatery.dto.review.ReviewDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
@@ -18,8 +16,8 @@ import java.util.List;
 @Getter
 public class ReviewCreateRequest {
 
-    @Schema(description = "리뷰를 작성하고자 하는 장소 정보")
-    private PlaceCreateRequest place;
+    @Schema(description = "PK of place", example = "3")
+    private Long placeId;
 
     @Schema(description = "키워드 목록", example = "[\"신선한 재료\", \"최고의 맛\"]")
     @NotEmpty
@@ -78,8 +76,8 @@ public class ReviewCreateRequest {
     @NonNull
     private List<ReviewImageCreateRequest> images;
 
-    public static ReviewCreateRequest of(PlaceCreateRequest place, List<String> keywords, String autoCreatedContent, String content, List<ReviewImageCreateRequest> images) {
-        return new ReviewCreateRequest(place, keywords, autoCreatedContent, content, images);
+    public static ReviewCreateRequest of(long placeId, List<String> keywords, String autoCreatedContent, String content, List<ReviewImageCreateRequest> images) {
+        return new ReviewCreateRequest(placeId, keywords, autoCreatedContent, content, images);
     }
 
     public ReviewDto toDto(PlaceDto placeDto) {

--- a/src/main/java/com/zelusik/eatery/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/service/ReviewService.java
@@ -7,7 +7,6 @@ import com.zelusik.eatery.domain.review.ReviewImage;
 import com.zelusik.eatery.domain.review.ReviewImageMenuTag;
 import com.zelusik.eatery.domain.review.ReviewKeyword;
 import com.zelusik.eatery.dto.place.PlaceDto;
-import com.zelusik.eatery.dto.place.request.PlaceCreateRequest;
 import com.zelusik.eatery.dto.review.ReviewDto;
 import com.zelusik.eatery.dto.review.request.ReviewCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewImageCreateRequest;
@@ -44,21 +43,12 @@ public class ReviewService {
      *
      * @param writerId      리뷰를 생성하고자 하는 회원의 PK.
      * @param reviewRequest 생성할 리뷰의 정보. 여기에 장소 정보도 포함되어 있다.
-     * @param images        리뷰와 함께 업로드 할 파일 목록
      * @return 생성된 리뷰 정보가 담긴 dto.
      */
     @Transactional
     public ReviewDto create(Long writerId, ReviewCreateRequest reviewRequest) {
         List<ReviewImageCreateRequest> images = reviewRequest.getImages();
-
-        // 장소 조회 or 저장
-        PlaceCreateRequest placeCreateRequest = reviewRequest.getPlace();
-        Place place = placeService.findOptByKakaoPid(placeCreateRequest.getKakaoPid())
-                .orElseGet(() -> {
-                    Long createdPlaceId = placeService.create(writerId, placeCreateRequest).getId();
-                    return placeService.findById(createdPlaceId);
-                });
-
+        Place place = placeService.findById(reviewRequest.getPlaceId());
         Member writer = memberService.findById(writerId);
         boolean placeMarkedStatus = bookmarkService.isMarkedPlace(writerId, place);
 

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -50,23 +50,15 @@ class ReviewControllerTest {
     @Test
     void givenReviewInfo_whenReviewCreate_thenReturnSavedReview() throws Exception {
         // given
+        long placeId = 3L;
         given(reviewService.create(any(), any(ReviewCreateRequest.class))).willReturn(ReviewTestUtils.createReviewDto());
 
         // when & then
-        ReviewCreateRequest reviewCreateRequest = ReviewTestUtils.createReviewCreateRequest();
+        ReviewCreateRequest reviewCreateRequest = ReviewTestUtils.createReviewCreateRequest(placeId);
         mvc.perform(
                         multipart("/api/reviews")
                                 .file(MultipartFileTestUtils.createMockMultipartFile())
-                                .param("place.kakaoPid", reviewCreateRequest.getPlace().getKakaoPid())
-                                .param("place.name", reviewCreateRequest.getPlace().getName())
-                                .param("place.pageUrl", reviewCreateRequest.getPlace().getPageUrl())
-                                .param("place.categoryGroupCode", reviewCreateRequest.getPlace().getCategoryGroupCode().toString())
-                                .param("place.categoryName", reviewCreateRequest.getPlace().getCategoryName())
-                                .param("place.phone", reviewCreateRequest.getPlace().getPhone())
-                                .param("place.lotNumberAddress", reviewCreateRequest.getPlace().getLotNumberAddress())
-                                .param("place.roadAddress", reviewCreateRequest.getPlace().getRoadAddress())
-                                .param("place.lat", reviewCreateRequest.getPlace().getLat())
-                                .param("place.lng", reviewCreateRequest.getPlace().getLng())
+                                .param("placeId", String.valueOf(placeId))
                                 .param("keywords", "신선한 재료", "왁자지껄한")
                                 .param("autoCreatedContent", reviewCreateRequest.getAutoCreatedContent())
                                 .param("content", reviewCreateRequest.getContent())

--- a/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
@@ -20,9 +20,9 @@ import java.util.List;
 
 public class ReviewTestUtils {
 
-    public static ReviewCreateRequest createReviewCreateRequest() {
+    public static ReviewCreateRequest createReviewCreateRequest(long placeId) {
         return ReviewCreateRequest.of(
-                PlaceTestUtils.createPlaceRequest(),
+                placeId,
                 List.of("신선한 재료"),
                 "자동 생성된 내용",
                 "제출한 내용",


### PR DESCRIPTION
## 🔥 Related Issue
- Close #271

## 🏃‍ Task
-  리뷰 생성 시 장소(Place)를 생성 및 저장하지 않도록 리팩토링
  - 리뷰 생성에 대한 business logic 수정
  - 리뷰 생성 시 전달받는 요청 데이터 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
