### PR TITLE
리뷰 이미지 저장 시 `url`과 `thumbnail_stored_name`이 뒤바뀌어 저장되는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/review/ReviewImage.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/ReviewImage.java
@@ -36,7 +36,7 @@ public class ReviewImage extends S3Image {
         return new ReviewImage(id, review, originalName, storedName, url, thumbnailStoredName, thumbnailUrl, createdAt, updatedAt, deletedAt);
     }
 
-    private ReviewImage(Long id, Review review, String originalName, String storedName, String thumbnailStoredName, String url, String thumbnailUrl, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+    private ReviewImage(Long id, Review review, String originalName, String storedName, String url, String thumbnailStoredName, String thumbnailUrl, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         super(originalName, storedName, url, thumbnailStoredName, thumbnailUrl, createdAt, updatedAt);
         this.id = id;
         this.review = review;


### PR DESCRIPTION
## 🔥 Related Issue
- Close #273

## 🏃‍ Task
- 리뷰 이미지 저장 시 `url`과 `thumbnail_stored_name`이 뒤바뀌어 저장되는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
