### PR TITLE
메뉴에 대한 키워드(맛, 평가, 느낌 등) 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/zelusik/eatery/constant/MenuKeywordCategory.java
+++ b/src/main/java/com/zelusik/eatery/constant/MenuKeywordCategory.java
@@ -1,0 +1,9 @@
+package com.zelusik.eatery.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum MenuKeywordCategory {
+
+    DEFAULT, MENU_NAME, PLACE_CATEGORY
+}

--- a/src/main/java/com/zelusik/eatery/controller/MenuKeywordController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MenuKeywordController.java
@@ -1,0 +1,75 @@
+package com.zelusik.eatery.controller;
+
+import com.zelusik.eatery.constant.MenuKeywordCategory;
+import com.zelusik.eatery.domain.place.PlaceCategory;
+import com.zelusik.eatery.dto.menu_keyword.response.MenuKeywordListResponseList;
+import com.zelusik.eatery.dto.menu_keyword.response.MenuKeywordResponse;
+import com.zelusik.eatery.service.MenuKeywordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.NotBlank;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.zelusik.eatery.constant.MenuKeywordCategory.MENU_NAME;
+import static com.zelusik.eatery.constant.MenuKeywordCategory.PLACE_CATEGORY;
+
+@RequestMapping("/api/menu-keywords")
+@Validated
+@RequiredArgsConstructor
+@RestController
+public class MenuKeywordController {
+
+    private final MenuKeywordService menuKeywordService;
+
+    @Operation(
+            summary = "메뉴 키워드 조회",
+            description = "각 메뉴에 대해 적절한 키워드 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @GetMapping
+    public MenuKeywordListResponseList getMenuKeywords(
+            @Parameter(
+                    description = "<p>리뷰를 작성하고자 하는 장소의 카테고리 중 첫 번째 카테고리. " +
+                            "<p>\"한식 > 육류,고기 > 삼겹살\" 중 \"한식\"에 해당한다.",
+                    example = "한식"
+            ) @RequestParam @NotBlank String firstCategory,
+            @Parameter(
+                    description = "<p>리뷰를 작성하고자 하는 장소의 카테고리 중 두 번째 카테고리. " +
+                            "<p>\"한식 > 육류,고기 > 삼겹살\" 중 \"육류,고기\"에 해당한다.",
+                    example = "육류,고기"
+            ) @RequestParam(required = false) String secondCategory,
+            @Parameter(
+                    description = "<p>리뷰를 작성하고자 하는 장소의 카테고리 중 세 번째 카테고리. " +
+                            "<p>\"한식 > 육류,고기 > 삼겹살\" 중 \"삼겹살\"에 해당한다.",
+                    example = "삼겹살"
+            ) @RequestParam(required = false) String thirdCategory,
+            @Parameter(
+                    description = "키워드를 조회하고자 하는 메뉴 목록",
+                    example = "[\"시금치 카츠 카레\", \"버터치킨카레\"]"
+            ) @RequestParam List<@NotBlank String> menus
+    ) {
+        EnumMap<MenuKeywordCategory, List<String>> namesMap = new EnumMap<>(Map.of(
+                MENU_NAME, menuKeywordService.getNamesForCategory(MENU_NAME).getContent(),
+                PLACE_CATEGORY, menuKeywordService.getNamesForCategory(PLACE_CATEGORY).getContent()
+        ));
+        List<String> defaultKeywords = menuKeywordService.getDefaultKeywords().getContent();
+
+        List<MenuKeywordResponse> result = menuKeywordService.getKeywords(
+                new PlaceCategory(firstCategory, secondCategory, thirdCategory),
+                menus,
+                namesMap,
+                defaultKeywords
+        );
+        return new MenuKeywordListResponseList(result);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/converter/MenuKeywordsConverter.java
+++ b/src/main/java/com/zelusik/eatery/converter/MenuKeywordsConverter.java
@@ -1,0 +1,28 @@
+package com.zelusik.eatery.converter;
+
+import org.springframework.lang.Nullable;
+
+import javax.persistence.AttributeConverter;
+import java.util.Arrays;
+import java.util.List;
+
+public class MenuKeywordsConverter implements AttributeConverter<List<String>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(@Nullable List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        return String.join(DELIMITER, attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(@Nullable String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(dbData.split(DELIMITER)).toList();
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/MenuKeyword.java
+++ b/src/main/java/com/zelusik/eatery/domain/MenuKeyword.java
@@ -1,0 +1,47 @@
+package com.zelusik.eatery.domain;
+
+import com.zelusik.eatery.constant.MenuKeywordCategory;
+import com.zelusik.eatery.converter.MenuKeywordsConverter;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class MenuKeyword extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menu_keyword_id")
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MenuKeywordCategory category;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    @Convert(converter = MenuKeywordsConverter.class)
+    private List<String> keywords;
+
+    public static MenuKeyword of(@Nullable Long id, @NonNull MenuKeywordCategory category, @NonNull String name, @NonNull List<String> keywords, @Nullable LocalDateTime createdAt, @Nullable LocalDateTime updatedAt) {
+        return new MenuKeyword(id, category, name, keywords, createdAt, updatedAt);
+    }
+
+    private MenuKeyword(@Nullable Long id, @NonNull MenuKeywordCategory category, String name, @NonNull List<String> keywords, @Nullable LocalDateTime createdAt, @Nullable LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
+        this.category = category;
+        this.name = name;
+        this.keywords = keywords;
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/MenuKeyword.java
+++ b/src/main/java/com/zelusik/eatery/domain/MenuKeyword.java
@@ -33,6 +33,10 @@ public class MenuKeyword extends BaseTimeEntity {
     @Convert(converter = MenuKeywordsConverter.class)
     private List<String> keywords;
 
+    public static MenuKeyword of(@NonNull MenuKeywordCategory category, @NonNull String name, @NonNull List<String> keywords) {
+        return new MenuKeyword(null, category, name, keywords, null, null);
+    }
+
     public static MenuKeyword of(@Nullable Long id, @NonNull MenuKeywordCategory category, @NonNull String name, @NonNull List<String> keywords, @Nullable LocalDateTime createdAt, @Nullable LocalDateTime updatedAt) {
         return new MenuKeyword(id, category, name, keywords, createdAt, updatedAt);
     }

--- a/src/main/java/com/zelusik/eatery/domain/place/PlaceCategory.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/PlaceCategory.java
@@ -18,21 +18,23 @@ import java.util.Objects;
 @Embeddable
 public class PlaceCategory {
 
-    @Schema(description = "카테고리 1", example = "퓨전요리")
+    private static final String CATEGORY_DELIMITER = " > ";
+
+    @Schema(description = "카테고리 1", example = "한식")
     @NonNull
     @Column(nullable = false)
     private String firstCategory;
 
-    @Schema(description = "카테고리 2", example = "퓨전일식")
+    @Schema(description = "카테고리 2", example = "육류,고기")
     @Nullable
     private String secondCategory;
 
-    @Schema(description = "카테고리 3")
+    @Schema(description = "카테고리 3", example = "삼겹살")
     @Nullable
     private String thirdCategory;
 
     public static PlaceCategory of(String categoryName) {
-        String[] categories = categoryName.split(" > ");
+        String[] categories = categoryName.split(CATEGORY_DELIMITER);
         int length = categories.length;
 
         String firstCategory = length > 1 ? categories[1] : "";
@@ -54,5 +56,16 @@ public class PlaceCategory {
     @Override
     public int hashCode() {
         return Objects.hash(getFirstCategory(), getSecondCategory(), getThirdCategory());
+    }
+
+    public String concatAllCategories() {
+        String result = getFirstCategory();
+        if (getSecondCategory() != null && !getSecondCategory().isBlank()) {
+            result += CATEGORY_DELIMITER + getSecondCategory();
+        }
+        if (getThirdCategory() != null && !getThirdCategory().isBlank()) {
+            result += CATEGORY_DELIMITER + getThirdCategory();
+        }
+        return result;
     }
 }

--- a/src/main/java/com/zelusik/eatery/dto/ListDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/ListDto.java
@@ -1,0 +1,21 @@
+package com.zelusik.eatery.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 기본적으로 redis caching을 위해 만든 dto class.
+ * List는 역직렬화 문제가 있기 때문에 caching하기 위한 dto class로 사용하고자 한다.
+ *
+ * @reference https://bcp0109.tistory.com/384
+ */
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ListDto<T> {
+    private List<T> content;
+}

--- a/src/main/java/com/zelusik/eatery/dto/menu_keyword/response/MenuKeywordListResponseList.java
+++ b/src/main/java/com/zelusik/eatery/dto/menu_keyword/response/MenuKeywordListResponseList.java
@@ -1,0 +1,16 @@
+package com.zelusik.eatery.dto.menu_keyword.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MenuKeywordListResponseList {
+
+    private List<MenuKeywordResponse> menuKeywords;
+}

--- a/src/main/java/com/zelusik/eatery/dto/menu_keyword/response/MenuKeywordResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/menu_keyword/response/MenuKeywordResponse.java
@@ -1,0 +1,21 @@
+package com.zelusik.eatery.dto.menu_keyword.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MenuKeywordResponse {
+
+    @Schema(description = "메뉴 이름", example = "버터치킨카레")
+    private String menu;
+
+    @Schema(description = "메뉴에 해당하는 키워드 목록 (최대 10개)", example = "[\"단짠\", \"부드러운\", \"촉촉한\", \"짭조름한\", \"노릇노릇\"]")
+    private List<String> keywords;
+}

--- a/src/main/java/com/zelusik/eatery/repository/MenuKeywordRepository.java
+++ b/src/main/java/com/zelusik/eatery/repository/MenuKeywordRepository.java
@@ -1,0 +1,7 @@
+package com.zelusik.eatery.repository;
+
+import com.zelusik.eatery.domain.MenuKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuKeywordRepository extends JpaRepository<MenuKeyword, Long> {
+}

--- a/src/main/java/com/zelusik/eatery/repository/MenuKeywordRepository.java
+++ b/src/main/java/com/zelusik/eatery/repository/MenuKeywordRepository.java
@@ -1,7 +1,0 @@
-package com.zelusik.eatery.repository;
-
-import com.zelusik.eatery.domain.MenuKeyword;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface MenuKeywordRepository extends JpaRepository<MenuKeyword, Long> {
-}

--- a/src/main/java/com/zelusik/eatery/repository/menu_keyword/MenuKeywordRepository.java
+++ b/src/main/java/com/zelusik/eatery/repository/menu_keyword/MenuKeywordRepository.java
@@ -1,0 +1,7 @@
+package com.zelusik.eatery.repository.menu_keyword;
+
+import com.zelusik.eatery.domain.MenuKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuKeywordRepository extends JpaRepository<MenuKeyword, Long>, MenuKeywordRepositoryQCustom {
+}

--- a/src/main/java/com/zelusik/eatery/repository/menu_keyword/MenuKeywordRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/repository/menu_keyword/MenuKeywordRepositoryQCustom.java
@@ -1,0 +1,16 @@
+package com.zelusik.eatery.repository.menu_keyword;
+
+import com.zelusik.eatery.constant.MenuKeywordCategory;
+import com.zelusik.eatery.domain.MenuKeyword;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MenuKeywordRepositoryQCustom {
+
+    Optional<MenuKeyword> getDefaultMenuKeyword();
+
+    List<String> getNamesByCategory(MenuKeywordCategory category);
+
+    List<MenuKeyword> getAllByNames(List<String> names);
+}

--- a/src/main/java/com/zelusik/eatery/repository/menu_keyword/MenuKeywordRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/menu_keyword/MenuKeywordRepositoryQCustomImpl.java
@@ -1,0 +1,41 @@
+package com.zelusik.eatery.repository.menu_keyword;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zelusik.eatery.constant.MenuKeywordCategory;
+import com.zelusik.eatery.domain.MenuKeyword;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.zelusik.eatery.domain.QMenuKeyword.menuKeyword;
+
+@RequiredArgsConstructor
+public class MenuKeywordRepositoryQCustomImpl implements MenuKeywordRepositoryQCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MenuKeyword> getDefaultMenuKeyword() {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(menuKeyword)
+                        .where(menuKeyword.category.eq(MenuKeywordCategory.DEFAULT))
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public List<String> getNamesByCategory(MenuKeywordCategory category) {
+        return queryFactory.select(menuKeyword.name)
+                .from(menuKeyword)
+                .where(menuKeyword.category.eq(category))
+                .fetch();
+    }
+
+    @Override
+    public List<MenuKeyword> getAllByNames(List<String> names) {
+        return queryFactory.selectFrom(menuKeyword)
+                .where(menuKeyword.name.in(names))
+                .fetch();
+    }
+}

--- a/src/main/java/com/zelusik/eatery/service/MenuKeywordService.java
+++ b/src/main/java/com/zelusik/eatery/service/MenuKeywordService.java
@@ -1,0 +1,83 @@
+package com.zelusik.eatery.service;
+
+import com.zelusik.eatery.constant.MenuKeywordCategory;
+import com.zelusik.eatery.domain.MenuKeyword;
+import com.zelusik.eatery.domain.place.PlaceCategory;
+import com.zelusik.eatery.dto.ListDto;
+import com.zelusik.eatery.dto.menu_keyword.response.MenuKeywordResponse;
+import com.zelusik.eatery.repository.menu_keyword.MenuKeywordRepository;
+import lombok.*;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+import static com.zelusik.eatery.constant.MenuKeywordCategory.MENU_NAME;
+import static com.zelusik.eatery.constant.MenuKeywordCategory.PLACE_CATEGORY;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MenuKeywordService {
+    private static final int MAX_NUM_OF_RESULTS = 10;
+
+    private final MenuKeywordRepository menuKeywordRepository;
+
+    @NonNull
+    public List<MenuKeywordResponse> getKeywords(
+            PlaceCategory placeCategory,
+            List<String> menus,
+            EnumMap<MenuKeywordCategory, List<String>> namesMap,
+            List<String> defaultKeywords
+    ) {
+        // (+ namesMap) 같은 결과가 나오는 중복 query 생성을 방지하기 위해 method 단위로 한 번 조회한 값을 유지한다.
+        List<MenuKeywordResponse> result = new ArrayList<>();
+
+        for (String menu : menus) {
+            Set<String> keywords = new LinkedHashSet<>(); // 데이터가 쌓인 순서 대로 앞에서 MAX_NUM_OF_RESULTS 만큼 자를 것 이므로 LinkedHashSet 사용
+
+            keywords.addAll(getKeywordsForCategory(namesMap, MENU_NAME, menu));
+            if (keywords.size() >= MAX_NUM_OF_RESULTS) {
+                result.add(createMenuKeywordResponse(menu, keywords));
+                continue;
+            }
+
+            String placeCategories = placeCategory.concatAllCategories();
+            keywords.addAll(getKeywordsForCategory(namesMap, PLACE_CATEGORY, placeCategories));
+            if (keywords.size() >= MAX_NUM_OF_RESULTS) {
+                result.add(createMenuKeywordResponse(menu, keywords));
+                continue;
+            }
+
+            keywords.addAll(defaultKeywords);
+            result.add(createMenuKeywordResponse(menu, keywords));
+        }
+        return result;
+    }
+
+    @Cacheable(value = "names", key = "#category")
+    public ListDto<String> getNamesForCategory(MenuKeywordCategory category) {
+        return new ListDto<>(menuKeywordRepository.getNamesByCategory(category));
+    }
+
+    @Cacheable(value = "menu_keywords", key = "'default'")
+    public ListDto<String> getDefaultKeywords() {
+        return new ListDto<>(menuKeywordRepository.getDefaultMenuKeyword()
+                .map(MenuKeyword::getKeywords)
+                .orElse(List.of()));
+    }
+
+    private List<String> getKeywordsForCategory(EnumMap<MenuKeywordCategory, List<String>> namesMap, MenuKeywordCategory category, String query) {
+        List<String> result = new ArrayList<>();
+        List<String> filteredNames = namesMap.get(category).stream().filter(query::contains).toList();
+        menuKeywordRepository.getAllByNames(filteredNames)
+                .forEach(menuKeyword -> result.addAll(menuKeyword.getKeywords()));
+        return result;
+    }
+
+    private MenuKeywordResponse createMenuKeywordResponse(String menu, Set<String> keywords) {
+        return new MenuKeywordResponse(menu, keywords.stream().limit(MAX_NUM_OF_RESULTS).toList());
+    }
+}

--- a/src/test/java/com/zelusik/eatery/integration/controller/MenuKeywordControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/controller/MenuKeywordControllerTest.java
@@ -1,0 +1,82 @@
+package com.zelusik.eatery.integration.controller;
+
+import com.zelusik.eatery.config.JpaConfig;
+import com.zelusik.eatery.config.QuerydslConfig;
+import com.zelusik.eatery.controller.MenuKeywordController;
+import com.zelusik.eatery.domain.MenuKeyword;
+import com.zelusik.eatery.dto.menu_keyword.response.MenuKeywordResponse;
+import com.zelusik.eatery.repository.menu_keyword.MenuKeywordRepository;
+import com.zelusik.eatery.service.MenuKeywordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static com.zelusik.eatery.constant.MenuKeywordCategory.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+@DisplayName("[Integration] Menu keyword service")
+@ActiveProfiles("test")
+@Import({MenuKeywordController.class, MenuKeywordService.class, QuerydslConfig.class, JpaConfig.class})
+@DataJpaTest
+class MenuKeywordControllerTest {
+
+    private final MenuKeywordRepository menuKeywordRepository;
+    private final MenuKeywordController sut;
+
+    @Autowired
+    public MenuKeywordControllerTest(MenuKeywordRepository menuKeywordRepository, MenuKeywordController menuKeywordController) {
+        this.menuKeywordRepository = menuKeywordRepository;
+        this.sut = menuKeywordController;
+    }
+
+    @BeforeEach
+    void createTestData() {
+        menuKeywordRepository.save(MenuKeyword.of(DEFAULT, "", List.of("다양한", "상큼한", "짭조름한", "달콤한", "매콤한", "독특한")));
+        menuKeywordRepository.save(MenuKeyword.of(PLACE_CATEGORY, "일본식라면", List.of("강렬한", "탱글탱글한", "쫄깃한", "매콤한", "깊은", "다채로운", "조화로운")));
+        menuKeywordRepository.save(MenuKeyword.of(PLACE_CATEGORY, "육류,고기", List.of("살살 녹는", "탱글탱글한", "짭조름한", "겉바속촉", "풍미 있는", "새콤달콤한", "깊은")));
+        menuKeywordRepository.save(MenuKeyword.of(PLACE_CATEGORY, "햄버거", List.of("신박한", "바삭한", "부드러운", "가벼운", "감칠맛 나는", "짭짤한", "건강한")));
+        menuKeywordRepository.save(MenuKeyword.of(PLACE_CATEGORY, "일식", List.of("신선한", "깔끔한", "감칠맛 나는", "독특한", "다양한", "고급진")));
+        menuKeywordRepository.save(MenuKeyword.of(PLACE_CATEGORY, "중국요리", List.of("짭쪼름한", "독특한", "불맛이 나는", "깊은", "달콤한", "풍부한", "다양한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "곰탕", List.of("진한", "고소한", "푸짐한", "건강에 좋은", "부드러운", "담백한", "깊은", "고기가 가득한", "시원한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "국밥", List.of("진한", "고소한", "푸짐한", "건강에 좋은", "부드러운", "짭짤한", "담백한", "깊은", "고기가 가득한", "시원한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "국수", List.of("쫄깃한", "매콤한", "감칠맛 나는", "부드러운", "시원한", "짭조름한", "담백한", "입맛이 돋는", "상큼한", "고소한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "냉면", List.of("쫄깃한", "매콤한", "감칠맛 나는", "시원한", "짭조름한", "담백한", "입맛이 돋는", "상큼한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "닭강정", List.of("바삭한", "달콤한", "매콤한", "담백한", "고소한", "육즙이 살아있는")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "도넛", List.of("달콤한", "바삭한", "촉촉한", "고급스러운", "독특한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "까스", List.of("바삭한", "촉촉한", "입에서 살살 녹는", "담백한", "푸짐한", "매콤한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "우동", List.of("쫄깃한", "깊은 맛", "담백한", "오동통한", "상큼한", "뜨끈한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "두부", List.of("고소한", "야들야들한")));
+        menuKeywordRepository.save(MenuKeyword.of(MENU_NAME, "버거", List.of("신선한", "바삭한", "부드러운", "가벼운", "감칠맛 나는", "짭짤한", "건강한")));
+    }
+
+    @DisplayName("장소 카테고리와 메뉴 목록이 담긴 요청 데이터가 주어지고, 각 메뉴에 적절한 키워드 목록을 조회하면, 조회된 키워드 목록을 반환한다.")
+    @Test
+    void givenMenuKeywordGetRequest_whenGetKeywords_thenReturnKeywords() {
+        // given
+        List<MenuKeywordResponse> expectedResults = List.of(
+                new MenuKeywordResponse("까스버거", List.of("바삭한", "촉촉한", "입에서 살살 녹는", "담백한", "푸짐한", "매콤한", "신선한", "부드러운", "가벼운", "감칠맛 나는")),   // 메뉴 이름 "까스", "버거"에 매칭
+                new MenuKeywordResponse("버거", List.of("신선한", "바삭한", "부드러운", "가벼운", "감칠맛 나는", "짭짤한", "건강한", "신박한", "다양한", "상큼한")), // 메뉴 이름 "버거", 카테고리 "햄버거"에 매칭, 기본 키워드 포함
+                new MenuKeywordResponse("특이한거", List.of("신박한", "바삭한", "부드러운", "가벼운", "감칠맛 나는", "짭짤한", "건강한", "다양한", "상큼한", "짭조름한")) // 카테고리 "햄버거"에 매칭, 기본 키워드 포함
+        );
+
+        // when
+        List<MenuKeywordResponse> actualResults = sut.getMenuKeywords("양식", "햄버거", null, List.of("까스버거", "버거", "특이한거")).getMenuKeywords();
+
+        // then
+        assertThat(actualResults).isNotEmpty();
+        assertThat(actualResults.size()).isEqualTo(expectedResults.size());
+        for (int i = 0; i < expectedResults.size(); i++) {
+            MenuKeywordResponse expectedResult = expectedResults.get(i);
+            MenuKeywordResponse actualResult = actualResults.get(i);
+            assertThat(actualResult.getMenu()).isEqualTo(expectedResult.getMenu());
+            assertIterableEquals(expectedResult.getKeywords(), actualResult.getKeywords());
+        }
+    }
+}

--- a/src/test/java/com/zelusik/eatery/integration/repository/menu_keyword/MenuKeywordRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/repository/menu_keyword/MenuKeywordRepositoryTest.java
@@ -1,0 +1,123 @@
+package com.zelusik.eatery.integration.repository.menu_keyword;
+
+import com.zelusik.eatery.config.JpaConfig;
+import com.zelusik.eatery.config.QuerydslConfig;
+import com.zelusik.eatery.domain.MenuKeyword;
+import com.zelusik.eatery.repository.menu_keyword.MenuKeywordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.zelusik.eatery.constant.MenuKeywordCategory.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+@DisplayName("[Integration] MenuKeyword Repository")
+@Import({QuerydslConfig.class, JpaConfig.class})
+@ActiveProfiles("test")
+@DataJpaTest
+class MenuKeywordRepositoryTest {
+
+    private final MenuKeywordRepository sut;
+
+    public MenuKeywordRepositoryTest(@Autowired MenuKeywordRepository sut) {
+        this.sut = sut;
+    }
+
+    @BeforeEach
+    void createTestData() {
+        sut.save(MenuKeyword.of(DEFAULT, "", List.of("다양한", "상큼한", "짭조름한", "달콤한", "매콤한", "독특한")));
+        sut.save(MenuKeyword.of(PLACE_CATEGORY, "일본식라면", List.of("강렬한", "탱글탱글한", "쫄깃한", "매콤한", "깊은", "다채로운", "조화로운")));
+        sut.save(MenuKeyword.of(PLACE_CATEGORY, "육류,고기", List.of("살살 녹는", "탱글탱글한", "짭조름한", "겉바속촉", "풍미 있는", "새콤달콤한", "깊은")));
+        sut.save(MenuKeyword.of(PLACE_CATEGORY, "햄버거", List.of("신선한", "바삭한", "부드러운", "가벼운", "감칠맛 나는", "짭짤한", "건강한")));
+        sut.save(MenuKeyword.of(PLACE_CATEGORY, "일식", List.of("신선한", "깔끔한", "감칠맛 나는", "독특한", "다양한", "고급진")));
+        sut.save(MenuKeyword.of(PLACE_CATEGORY, "중국요리", List.of("짭쪼름한", "독특한", "불맛이 나는", "깊은", "달콤한", "풍부한", "다양한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "곰탕", List.of("진한", "고소한", "푸짐한", "건강에 좋은", "부드러운", "담백한", "깊은", "고기가 가득한", "시원한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "국밥", List.of("진한", "고소한", "푸짐한", "건강에 좋은", "부드러운", "짭짤한", "담백한", "깊은", "고기가 가득한", "시원한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "국수", List.of("쫄깃한", "매콤한", "감칠맛 나는", "부드러운", "시원한", "짭조름한", "담백한", "입맛이 돋는", "상큼한", "고소한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "냉면", List.of("쫄깃한", "매콤한", "감칠맛 나는", "시원한", "짭조름한", "담백한", "입맛이 돋는", "상큼한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "닭강정", List.of("바삭한", "달콤한", "매콤한", "담백한", "고소한", "육즙이 살아있는")));
+        sut.save(MenuKeyword.of(MENU_NAME, "도넛", List.of("달콤한", "바삭한", "촉촉한", "고급스러운", "독특한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "까스", List.of("바삭한", "촉촉한", "입에서 살살 녹는", "담백한", "푸짐한", "매콤한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "우동", List.of("쫄깃한", "깊은 맛", "담백한", "오동통한", "상큼한", "뜨끈한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "두부", List.of("고소한", "야들야들한")));
+        sut.save(MenuKeyword.of(MENU_NAME, "버거", List.of("신선한", "바삭한", "부드러운", "가벼운", "감칠맛 나는", "짭짤한", "건강한")));
+    }
+
+    @DisplayName("Default menu keyword를 조회한다.")
+    @Test
+    void given_whenGetDefaultMenuKeyword_thenReturnResult() {
+        // given
+
+        // when
+        Optional<MenuKeyword> result = sut.getDefaultMenuKeyword();
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get())
+                .hasFieldOrPropertyWithValue("category", DEFAULT)
+                .hasFieldOrPropertyWithValue("name", "")
+                .hasFieldOrPropertyWithValue("keywords", List.of("다양한", "상큼한", "짭조름한", "달콤한", "매콤한", "독특한"));
+    }
+
+    @DisplayName("카테고리가 MENU_NAME인 메뉴 키워드의 name list를 조회한다.")
+    @Test
+    void given_whenGetNamesWithCategoryIsMENU_NAME_thenReturnResult() {
+        // given
+        List<String> expectedResult = List.of("곰탕", "국밥", "국수", "냉면", "닭강정", "도넛", "까스", "우동", "두부", "버거");
+
+        // when
+        List<String> actualResult = sut.getNamesByCategory(MENU_NAME);
+
+        // then
+        assertThat(actualResult).isNotEmpty();
+        assertIterableEquals(expectedResult, actualResult);
+    }
+
+    @DisplayName("카테고리가 PLACE_CATEGORY인 메뉴 키워드의 name list를 조회한다.")
+    @Test
+    void given_whenGetNamesWithCategoryIsPLACE_CATEGORY_thenReturnResult() {
+        // given
+        List<String> expectedResult = List.of("일본식라면", "육류,고기", "햄버거", "일식", "중국요리");
+
+        // when
+        List<String> actualResult = sut.getNamesByCategory(PLACE_CATEGORY);
+
+        // then
+        assertThat(actualResult).isNotEmpty();
+        assertIterableEquals(expectedResult, actualResult);
+    }
+
+    @DisplayName("Name 목록이 주어지고, 주어진 이름들에 해당하는 메뉴 키워드 목록을 조회하면, 조회된 결과를 반환한다.")
+    @Test
+    void givenNames_whenGetMenuKeywordsMatchingNames_thenReturnResult() {
+        // given
+        List<String> names = List.of("햄버거", "일식", "두부");
+        List<MenuKeyword> expectedResults = List.of(
+                MenuKeyword.of(PLACE_CATEGORY, "햄버거", List.of("신선한", "바삭한", "부드러운", "가벼운", "감칠맛 나는", "짭짤한", "건강한")),
+                MenuKeyword.of(PLACE_CATEGORY, "일식", List.of("신선한", "깔끔한", "감칠맛 나는", "독특한", "다양한", "고급진")),
+                MenuKeyword.of(MENU_NAME, "두부", List.of("고소한", "야들야들한"))
+        );
+
+        // when
+        List<MenuKeyword> actualResults = sut.getAllByNames(names);
+
+        // then
+        assertThat(actualResults).isNotEmpty();
+        assertThat(actualResults.size()).isEqualTo(expectedResults.size());
+        for (int i = 0; i < expectedResults.size(); i++) {
+            MenuKeyword expectedResult = expectedResults.get(i);
+            MenuKeyword actualResult = actualResults.get(i);
+            assertThat(actualResult.getCategory()).isEqualTo(expectedResult.getCategory());
+            assertThat(actualResult.getName()).isEqualTo(expectedResult.getName());
+            assertIterableEquals(expectedResult.getKeywords(), actualResult.getKeywords());
+        }
+    }
+}

--- a/src/test/java/com/zelusik/eatery/unit/controller/MenuKeywordControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MenuKeywordControllerTest.java
@@ -1,0 +1,90 @@
+package com.zelusik.eatery.unit.controller;
+
+import com.zelusik.eatery.config.TestSecurityConfig;
+import com.zelusik.eatery.controller.MenuKeywordController;
+import com.zelusik.eatery.domain.place.PlaceCategory;
+import com.zelusik.eatery.dto.ListDto;
+import com.zelusik.eatery.dto.menu_keyword.response.MenuKeywordResponse;
+import com.zelusik.eatery.security.UserPrincipal;
+import com.zelusik.eatery.service.MenuKeywordService;
+import com.zelusik.eatery.util.MemberTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.EnumMap;
+import java.util.List;
+
+import static com.zelusik.eatery.constant.MenuKeywordCategory.MENU_NAME;
+import static com.zelusik.eatery.constant.MenuKeywordCategory.PLACE_CATEGORY;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("[Unit] Menu keyword controller")
+@MockBean(JpaMetamodelMappingContext.class)
+@Import(TestSecurityConfig.class)
+@WebMvcTest(controllers = MenuKeywordController.class)
+class MenuKeywordControllerTest {
+
+    @MockBean
+    private MenuKeywordService menuKeywordService;
+
+    private final MockMvc mvc;
+
+    @Autowired
+    public MenuKeywordControllerTest(MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("리뷰를 작성할 장소의 카테고리 정보와 키워드를 얻고자 하는 메뉴 목록이 주어지고, 메뉴에 대한 키워드를 조회하면, 조회된 키워드들을 반환한다.")
+    @Test
+    void givenPlaceCategoriesAndMenus_whenGetMenuKeywords_thenReturnKeywords() throws Exception {
+        // given
+        PlaceCategory placeCategory = new PlaceCategory("한식", "육류,고기", null);
+        List<String> menus = List.of("왕 생갈비", "한우 양념 갈비");
+        List<MenuKeywordResponse> expectedResults = List.of(
+                new MenuKeywordResponse(menus.get(0), List.of("감칠맛 나는")),
+                new MenuKeywordResponse(menus.get(1), List.of("매운", "퍽퍽한"))
+        );
+        given(menuKeywordService.getNamesForCategory(MENU_NAME)).willReturn(new ListDto<>(List.of()));
+        given(menuKeywordService.getNamesForCategory(PLACE_CATEGORY)).willReturn(new ListDto<>(List.of()));
+        given(menuKeywordService.getDefaultKeywords()).willReturn(new ListDto<>(List.of()));
+        given(menuKeywordService.getKeywords(eq(placeCategory), eq(menus), any(EnumMap.class), anyList())).willReturn(expectedResults);
+
+        // when & then
+        ResultActions resultActions = mvc.perform(
+                        get("/api/menu-keywords")
+                                .param("firstCategory", placeCategory.getFirstCategory())
+                                .param("secondCategory", placeCategory.getSecondCategory())
+                                .param("menus", menus.toArray(new String[0]))
+                                .with(user(createTestUserDetails()))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.menuKeywords").isArray())
+                .andExpect(jsonPath("$.menuKeywords", hasSize(menus.size())));
+        for (int i = 0; i < expectedResults.size(); i++) {
+            MenuKeywordResponse expectedResult = expectedResults.get(i);
+            resultActions
+                    .andExpect(jsonPath("$.menuKeywords[" + i + "].menu").value(expectedResult.getMenu()))
+                    .andExpect(jsonPath("$.menuKeywords[" + i + "].keywords", hasSize(expectedResult.getKeywords().size())));
+        }
+        resultActions.andDo(print());
+    }
+
+    private UserDetails createTestUserDetails() {
+        return UserPrincipal.of(MemberTestUtils.createMemberDtoWithId());
+    }
+}

--- a/src/test/java/com/zelusik/eatery/unit/service/MenuKeywordServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/MenuKeywordServiceTest.java
@@ -1,0 +1,144 @@
+package com.zelusik.eatery.unit.service;
+
+import com.zelusik.eatery.constant.MenuKeywordCategory;
+import com.zelusik.eatery.domain.MenuKeyword;
+import com.zelusik.eatery.domain.place.PlaceCategory;
+import com.zelusik.eatery.dto.menu_keyword.response.MenuKeywordResponse;
+import com.zelusik.eatery.repository.menu_keyword.MenuKeywordRepository;
+import com.zelusik.eatery.service.MenuKeywordService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.zelusik.eatery.constant.MenuKeywordCategory.MENU_NAME;
+import static com.zelusik.eatery.constant.MenuKeywordCategory.PLACE_CATEGORY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("[Unit] Menu keyword service")
+@ExtendWith(MockitoExtension.class)
+class MenuKeywordServiceTest {
+
+    @InjectMocks
+    private MenuKeywordService sut;
+
+    @Mock
+    private MenuKeywordRepository menuKeywordRepository;
+
+    @DisplayName("메뉴 키워드 조회 - 메뉴 이름에 대해 조회된 키워드가 10개 이상인 경우")
+    @Test
+    void givenTenOrMoreKeywordsForMenuName_whenGetKeywords_thenReturnKeywords() {
+        // given
+        String menuName = "새우버거";
+        EnumMap<MenuKeywordCategory, List<String>> namesMap = new EnumMap<>(Map.of(
+                MENU_NAME, List.of("새우", "버거"),
+                PLACE_CATEGORY, List.of()
+        ));
+        List<MenuKeyword> menuKeywordsFromNamesForMenuName = List.of(
+                MenuKeyword.of(MENU_NAME, "새우", List.of("1", "2", "3", "4", "5", "6")),
+                MenuKeyword.of(MENU_NAME, "버거", List.of("7", "8", "9", "10", "11", "12"))
+        );
+        List<MenuKeywordResponse> expectedResults = List.of(new MenuKeywordResponse(menuName, List.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")));
+        given(menuKeywordRepository.getAllByNames(namesMap.get(MENU_NAME))).willReturn(menuKeywordsFromNamesForMenuName);
+
+        // when
+        List<MenuKeywordResponse> actualResults = sut.getKeywords(
+                new PlaceCategory("first", null, null),
+                List.of(menuName),
+                namesMap,
+                List.of("100", "101", "102")
+        );
+
+        // then
+        then(menuKeywordRepository).should().getAllByNames(namesMap.get(MENU_NAME));
+        then(menuKeywordRepository).shouldHaveNoMoreInteractions();
+        assertThat(actualResults).isNotEmpty();
+        assertThat(actualResults.size()).isEqualTo(expectedResults.size());
+        for (int i = 0; i < expectedResults.size(); i++) {
+            MenuKeywordResponse expectedResult = expectedResults.get(i);
+            MenuKeywordResponse actualResult = actualResults.get(i);
+            assertThat(actualResult.getMenu()).isEqualTo(expectedResult.getMenu());
+            assertIterableEquals(expectedResult.getKeywords(), actualResult.getKeywords());
+        }
+    }
+
+    @DisplayName("메뉴 키워드 조회 - 메뉴 이름에 대한 키워드가 10개 미만이고, 장소 카테고리에 대한 키워드까지 포함하여 10개 이상인 경우")
+    @Test
+    void givenTenPlusKeywordsIncludingKeywordsForPlaceCategories_whenGetKeywords_thenReturnKeywords() {
+        // given
+        String menuName = "새우버거";
+        EnumMap<MenuKeywordCategory, List<String>> namesMap = new EnumMap<>(Map.of(
+                MENU_NAME, List.of("갈비", "버거"),
+                PLACE_CATEGORY, List.of("햄버거")
+        ));
+        List<MenuKeyword> menuKeywordsFromNamesForMenuName = List.of(MenuKeyword.of(MENU_NAME, "버거", List.of("1", "2", "3", "4", "5", "6")));
+        List<MenuKeyword> menuKeywordsFromNamesForPlaceCategory = List.of(MenuKeyword.of(PLACE_CATEGORY, "햄버거", List.of("7", "8", "9", "10", "11", "12")));
+        List<String> filteredNamesForMenuName = List.of("버거");
+        List<String> filteredNamesForPlaceCategory = List.of("햄버거");
+        List<MenuKeywordResponse> expectedResults = List.of(new MenuKeywordResponse(menuName, List.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")));
+        given(menuKeywordRepository.getAllByNames(filteredNamesForMenuName)).willReturn(menuKeywordsFromNamesForMenuName);
+        given(menuKeywordRepository.getAllByNames(filteredNamesForPlaceCategory)).willReturn(menuKeywordsFromNamesForPlaceCategory);
+
+        // when
+        List<MenuKeywordResponse> actualResults = sut.getKeywords(
+                new PlaceCategory("양식", "햄버거", null),
+                List.of(menuName),
+                namesMap,
+                List.of("100", "101", "102")
+        );
+
+        // then
+        then(menuKeywordRepository).should().getAllByNames(filteredNamesForMenuName);
+        then(menuKeywordRepository).should().getAllByNames(filteredNamesForPlaceCategory);
+        then(menuKeywordRepository).shouldHaveNoMoreInteractions();
+        assertThat(actualResults).isNotEmpty();
+        assertThat(actualResults.size()).isEqualTo(expectedResults.size());
+        for (int i = 0; i < expectedResults.size(); i++) {
+            MenuKeywordResponse expectedResult = expectedResults.get(i);
+            MenuKeywordResponse actualResult = actualResults.get(i);
+            assertThat(actualResult.getMenu()).isEqualTo(expectedResult.getMenu());
+            assertIterableEquals(expectedResult.getKeywords(), actualResult.getKeywords());
+        }
+    }
+
+    @DisplayName("메뉴 키워드 조회 - 메뉴 이름과 장소 카테고리에 대한 키워드가 10개 미만인 경우")
+    @Test
+    void givenLessThanTenKeywordsForMenuNamesAndPlaceCategories_whenGetKeywords_thenReturnResult() {
+        // given
+        String menuName = "독도새우 케이크";
+        EnumMap<MenuKeywordCategory, List<String>> namesMap = new EnumMap<>(Map.of(
+                MENU_NAME, List.of("갈비", "버거", "한우"),
+                PLACE_CATEGORY, List.of("양식", "일식")
+        ));
+        List<String> defaultKeywords = List.of("100", "101", "102");
+        List<MenuKeywordResponse> expectedResults = List.of(new MenuKeywordResponse(menuName, defaultKeywords));
+        given(menuKeywordRepository.getAllByNames(List.of())).willReturn(List.of());
+
+        // when
+        List<MenuKeywordResponse> actualResults = sut.getKeywords(
+                new PlaceCategory("카페", "테마카페", "디저트카페"),
+                List.of(menuName),
+                namesMap,
+                defaultKeywords
+        );
+
+        // then
+        assertThat(actualResults).isNotEmpty();
+        assertThat(actualResults.size()).isEqualTo(expectedResults.size());
+        for (int i = 0; i < expectedResults.size(); i++) {
+            MenuKeywordResponse expectedResult = expectedResults.get(i);
+            MenuKeywordResponse actualResult = actualResults.get(i);
+            assertThat(actualResult.getMenu()).isEqualTo(expectedResult.getMenu());
+            assertIterableEquals(expectedResult.getKeywords(), actualResult.getKeywords());
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #232

## 🏃‍ Task
- 메뉴에 대한 키워드(맛, 평가, 느낌 등) 목록 조회 기능 구현
  - 메뉴 키워드 entity class 구현
  - JPA repository, Querydsl 사용한 custom repository 구현
  - business logic 구현
  - API 구현

## 📄 Reference
- [`EnumMap`에 대한 정보](https://www.manty.co.kr/bbs/detail/develop?id=61)
- [`Collections` => `XxxMap` 변환에 대한 방법 및 개념](https://ttl-blog.tistory.com/1232)

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
