### PR TITLE
[개발서버] 리뷰 업로드 API 호출 시 OutOfMemoryError 발생하는 문제 해결

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,4 +3,4 @@ WORKDIR /spring
 ARG JAR_FILE=/build/libs/eatery-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} /spring/app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-Duser.timezone=Asia/Seoul", "-jar", "/spring/app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-Duser.timezone=Asia/Seoul", "-Xms512m", "-Xmx512m", "-jar", "/spring/app.jar"]


### PR DESCRIPTION
## 🔥 Related Issue
- Close #276 

## 🏃‍ Task
t2.micro 환경에서 할당된 memory는 1GB이고, 이 환경에서 JVM의 heap memory는 최소 1/64, 최대 1/4 크기로 할당되기 때문에 최대 heap memory 용량이 부족해서 발생하는 문제로 보인다. 이에 Spring application 실행 시 JVM option을 통해 할당받을 수 있는 heap memory를 늘려주었다.

## 📄 Reference
- [AWS 배포환경에서 OOME 발생 시 해결방법](https://cupeanimus.tistory.com/60)
- [[Spring] SpringBoot 힙 메모리 증가시키는 방법/ (OutOfMemoryError)](https://seeminglyjs.tistory.com/385)

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
