### PR TITLE
저장한 장소 목록 조회 API - 장소 대표 이미지 개수 변경 로직 중 잘못된 query 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.zelusik.eatery.constant.ConstantUtil.MAX_NUM_OF_FILTERING_KEYWORDS;
-import static com.zelusik.eatery.service.PlaceService.MAX_NUM_OF_PLACE_IMAGES;
 
 public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
 
@@ -75,7 +74,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
     ) {
         // SELECT
         StringBuilder sql = new StringBuilder("SELECT p.place_id, p.top3keywords, p.kakao_pid, p.name, p.page_url, p.category_group_code, p.first_category, p.second_category, p.third_category, p.phone, p.sido, p.sgg, p.lot_number_address, p.road_address, p.homepage_url, p.lat, p.lng, p.closing_hours, p.created_at, p.updated_at, ");
-        for (int i = 1; i <= MAX_NUM_OF_PLACE_IMAGES; i++) {
+        for (int i = 1; i <= numOfPlaceImages; i++) {
             sql.append(String.join("ri" + i, POSTFIXES_OF_REVIEW_IMAGE_COLUMN_FOR_SELECT));
         }
         sql.append("(6371 * ACOS(COS(RADIANS(:lat)) * COS(RADIANS(lat)) * COS(RADIANS(lng) - RADIANS(:lng)) + SIN(RADIANS(:lat)) * SIN(RADIANS(lat)))) AS distance, ")
@@ -83,7 +82,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
 
         // FROM, JOIN
         sql.append("FROM place p ");
-        for (int i = 1; i <= MAX_NUM_OF_PLACE_IMAGES; i++) {
+        for (int i = 1; i <= numOfPlaceImages; i++) {
             sql.append("LEFT JOIN review_image ri")
                     .append(i)
                     .append(" ON ri")
@@ -111,7 +110,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
 
         // GROUP BY
         sql.append("GROUP BY p.place_id, p.top3keywords, p.kakao_pid, p.name, p.page_url, p.category_group_code, p.first_category, p.second_category, p.third_category, p.phone, p.sido, p.sgg, p.lot_number_address, p.road_address, p.homepage_url, p.lat, p.lng, p.closing_hours, p.created_at, p.updated_at, ");
-        for (int i = 1; i <= MAX_NUM_OF_PLACE_IMAGES; i++) {
+        for (int i = 1; i <= numOfPlaceImages; i++) {
             sql.append(String.join("ri" + i, POSTFIXES_OF_REVIEW_IMAGE_COLUMN_FOR_GROUP_BY));
         }
         sql.append("bm.bookmark_id, bm.member_id, bm.place_id, bm.created_at, bm.updated_at ");

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -36,6 +36,8 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
             ".review_id AS ", "_review_id, ",
             ".original_name AS ", "_original_name, ",
             ".stored_name AS ", "_stored_name, ",
+            ".url AS ", "_url, ",
+            ".thumbnail_stored_name AS ", "_thumbnail_stored_name, ",
             ".thumbnail_url AS ", "_thumbnail_url, ",
             ".created_at AS ", "_created_at, ",
             ".updated_at AS ", "_updated_at, ",


### PR DESCRIPTION
## 🔥 Related Issue
- Close #284

## 🏃‍ Task
- 장소 대표 이미지 개수 설정을 `PlaceService`의 상수값이 아닌 전달받은 parameter로 할 수 있도록 수정
- `SELECT` 문에서 누락된 column 추가

## 📄 Reference
- None
