### PR TITLE
검색 API 응답에 조회된 “전체 데이터 개수” 추가

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/PlaceController.java
+++ b/src/main/java/com/zelusik/eatery/controller/PlaceController.java
@@ -5,6 +5,7 @@ import com.zelusik.eatery.constant.place.DayOfWeek;
 import com.zelusik.eatery.constant.place.FilteringType;
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.place.Point;
+import com.zelusik.eatery.dto.PageResponse;
 import com.zelusik.eatery.dto.SliceResponse;
 import com.zelusik.eatery.dto.place.PlaceDto;
 import com.zelusik.eatery.dto.place.request.PlaceCreateRequest;
@@ -21,6 +22,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
@@ -126,12 +128,12 @@ public class PlaceController {
     }
 
     @Operation(
-            summary = "근처 장소 검색 (거리순 정렬)",
+            summary = "주변 장소 검색 (거리순 정렬)",
             description = "중심 좌표를 받아 중심 좌표에서 가까운 장소들을 검색합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
     @GetMapping("/near")
-    public SliceResponse<FindNearPlacesResponse> findNearPlaces(
+    public PageResponse<FindNearPlacesResponse> findNearPlaces(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "중심 위치 - 위도",
@@ -176,8 +178,8 @@ public class PlaceController {
             throw new InvalidTypeOfReviewKeywordValueException("분위기에 대한 값만 사용할 수 있습니다.");
         }
 
-        Slice<PlaceDto> searchedPlaceDtos = placeService.findDtosNearBy(userPrincipal.getMemberId(), foodCategory, daysOfWeek, preferredVibe, new Point(lat, lng), PageRequest.of(page, size));
-        return new SliceResponse<FindNearPlacesResponse>()
+        Page<PlaceDto> searchedPlaceDtos = placeService.findDtosNearBy(userPrincipal.getMemberId(), foodCategory, daysOfWeek, preferredVibe, new Point(lat, lng), PageRequest.of(page, size));
+        return new PageResponse<FindNearPlacesResponse>()
                 .from(searchedPlaceDtos.map(FindNearPlacesResponse::from));
     }
 

--- a/src/main/java/com/zelusik/eatery/dto/PageResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/PageResponse.java
@@ -1,0 +1,57 @@
+package com.zelusik.eatery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@Getter
+public class PageResponse<T> {
+
+    @Schema(description = "전체 page 수", example = "6")
+    private Integer totalPages;
+
+    @Schema(description = "조회된 전체 데이터 수", example = "155")
+    private Long totalElements;
+
+    @Schema(description = "첫 번째 page인지", example = "false")
+    private Boolean isFirst;
+
+    @Schema(description = "마지막 page인지", example = "true")
+    private Boolean isLast;
+
+    @Schema(description = "현재 page의 크기", example = "15")
+    private Integer size;
+
+    @Schema(description = "현재 page 번호", example = "0")
+    private Integer number;
+
+    @Schema(description = "응답 데이터 리스트")
+    private List<T> contents;
+
+    @Schema(description = "현재 page에 포함된 데이터 개수", example = "30")
+    private Integer numOfElements;
+
+    @Schema(description = "응답 데이터가 비어있는지", example = "false")
+    private Boolean isEmpty;
+
+    public PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.isFirst(),
+                page.isLast(),
+                page.getSize(),
+                page.getNumber(),
+                page.getContent(),
+                page.getNumberOfElements(),
+                page.isEmpty()
+        );
+    }
+}

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustom.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustom.java
@@ -7,6 +7,7 @@ import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.dto.place.PlaceDto;
 import com.zelusik.eatery.dto.place.PlaceFilteringKeywordDto;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
@@ -26,7 +27,7 @@ public interface PlaceRepositoryJCustom {
      * @param pageable         paging 정보
      * @return 조회한 장소 목록
      */
-    Slice<PlaceDto> findDtosNearBy(Long memberId, @Nullable FoodCategoryValue foodCategory, @Nullable List<DayOfWeek> daysOfWeek, @Nullable ReviewKeywordValue preferredVibe, Point center, int distanceLimit, int numOfPlaceImages, Pageable pageable);
+    Page<PlaceDto> findDtosNearBy(Long memberId, @Nullable FoodCategoryValue foodCategory, @Nullable List<DayOfWeek> daysOfWeek, @Nullable ReviewKeywordValue preferredVibe, Point center, int distanceLimit, int numOfPlaceImages, Pageable pageable);
 
     /**
      * 북마크에 저장한 장소 목록(Slice)을 조회합니다.

--- a/src/main/java/com/zelusik/eatery/service/PlaceService.java
+++ b/src/main/java/com/zelusik/eatery/service/PlaceService.java
@@ -3,7 +3,6 @@ package com.zelusik.eatery.service;
 import com.zelusik.eatery.constant.FoodCategoryValue;
 import com.zelusik.eatery.constant.place.DayOfWeek;
 import com.zelusik.eatery.constant.place.FilteringType;
-import com.zelusik.eatery.constant.place.PlaceSearchKeyword;
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.place.OpeningHours;
 import com.zelusik.eatery.domain.place.Place;
@@ -20,6 +19,7 @@ import com.zelusik.eatery.repository.place.OpeningHoursRepository;
 import com.zelusik.eatery.repository.place.PlaceRepository;
 import com.zelusik.eatery.repository.review.ReviewKeywordRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.NonNull;
@@ -159,7 +159,7 @@ public class PlaceService {
      * @param pageable      paging 정보
      * @return 조회한 장소 목록
      */
-    public Slice<PlaceDto> findDtosNearBy(
+    public Page<PlaceDto> findDtosNearBy(
             Long memberId,
             @Nullable FoodCategoryValue foodCategory,
             @Nullable List<DayOfWeek> daysOfWeek,

--- a/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -152,7 +153,7 @@ class PlaceControllerTest {
         FoodCategoryValue foodCategory = FoodCategoryValue.KOREAN;
         List<DayOfWeek> daysOfWeek = List.of(MON, WED, FRI);
         ReviewKeywordValue preferredVibe = ReviewKeywordValue.WITH_ALCOHOL;
-        SliceImpl<PlaceDto> expectedResult = new SliceImpl<>(List.of(createPlaceDtoWithMarkedStatusAndImages()), Pageable.ofSize(30), false);
+        PageImpl<PlaceDto> expectedResult = new PageImpl<>(List.of(createPlaceDtoWithMarkedStatusAndImages()), Pageable.ofSize(30), 1);
         given(placeService.findDtosNearBy(eq(1L), eq(foodCategory), eq(daysOfWeek), eq(preferredVibe), eq(point), any(Pageable.class))).willReturn(expectedResult);
 
         // when & then
@@ -166,7 +167,7 @@ class PlaceControllerTest {
                                 .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId())))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.hasContent").value(true))
+                .andExpect(jsonPath("$.isEmpty").value(false))
                 .andExpect(jsonPath("$.numOfElements").value(1))
                 .andDo(print());
     }

--- a/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
@@ -28,9 +28,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.*;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -283,7 +281,7 @@ class PlaceServiceTest {
         long memberId = 1L;
         Point point = new Point("37", "127");
         Pageable pageable = Pageable.ofSize(30);
-        SliceImpl<PlaceDto> expectedResult = new SliceImpl<>(List.of(createPlaceDtoWithMarkedStatusAndImages()), pageable, false);
+        Page<PlaceDto> expectedResult = new PageImpl<>(List.of(createPlaceDtoWithMarkedStatusAndImages()), pageable, 1);
         given(placeRepository.findDtosNearBy(memberId, null, null, null, point, 50, MAX_NUM_OF_PLACE_IMAGES, pageable)).willReturn(expectedResult);
 
         // when


### PR DESCRIPTION
## 🔥 Related Issue
- Close #300

## 🏃‍ Task
- 주변 장소 검색 API 응답 데이터 type 변경. `Slice` => `Page`

## 📄 Reference
- None
