### PR TITLE
feat: #338 회원 프로필 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MemberController.java
@@ -6,10 +6,7 @@ import com.zelusik.eatery.dto.member.MemberDto;
 import com.zelusik.eatery.dto.member.request.FavoriteFoodCategoriesUpdateRequest;
 import com.zelusik.eatery.dto.member.request.MemberUpdateRequest;
 import com.zelusik.eatery.dto.member.request.TermsAgreeRequest;
-import com.zelusik.eatery.dto.member.response.GetMyProfileInfoResponse;
-import com.zelusik.eatery.dto.member.response.MemberDeletionSurveyResponse;
-import com.zelusik.eatery.dto.member.response.MemberResponse;
-import com.zelusik.eatery.dto.member.response.SearchMembersByKeywordResponse;
+import com.zelusik.eatery.dto.member.response.*;
 import com.zelusik.eatery.dto.review.request.MemberDeletionSurveyRequest;
 import com.zelusik.eatery.dto.terms_info.response.TermsInfoResponse;
 import com.zelusik.eatery.security.UserPrincipal;
@@ -85,6 +82,33 @@ public class MemberController {
     @GetMapping("/me/profile")
     public GetMyProfileInfoResponse getMyProfileInfo(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         return GetMyProfileInfoResponse.from(memberService.getMemberProfileInfoById(userPrincipal.getMemberId()));
+    }
+
+    @Operation(
+            summary = "회원 프로필 정보 조회",
+            description = """
+                    <p>회원 id를 전달받아 일치하는 회원의 프로필 정보를 조회합니다.
+                    <p>회원 프로필 정보란 다음 항목들을 의미합니다.
+                    <ul>
+                        <li>회원 정보</li>
+                        <li>작성한 리뷰 수</li>
+                        <li>영향력</li>
+                        <li>팔로워 수</li>
+                        <li>팔로잉 수</li>
+                        <li>가장 많이 방문한 장소(읍면동)</li>
+                        <li>가장 많이 태그된 리뷰 키워드</li>
+                        <li>가장 많이 먹은 음식 카테고리</li>
+                    </ul>
+                    """,
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @ApiResponses({
+            @ApiResponse(description = "OK", responseCode = "200"),
+            @ApiResponse(description = "[2000] 전달받은 <code>memberId</code>에 해당하는 회원을 찾을 수 없는 경우", responseCode = "404", content = @Content)
+    })
+    @GetMapping("/{memberId}/profile")
+    public GetMemberProfileInfoResponse getMemberProfileInfo(@PathVariable Long memberId) {
+        return GetMemberProfileInfoResponse.from(memberService.getMemberProfileInfoById(memberId));
     }
 
     @Operation(

--- a/src/main/java/com/zelusik/eatery/dto/member/response/GetMemberProfileInfoResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/member/response/GetMemberProfileInfoResponse.java
@@ -1,0 +1,85 @@
+package com.zelusik.eatery.dto.member.response;
+
+import com.zelusik.eatery.dto.member.MemberProfileInfoDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetMemberProfileInfoResponse {
+
+    @Schema(description = "회원 id(PK)", example = "1")
+    private Long id;
+
+    @Schema(description = "프로필 이미지")
+    private MemberProfileImageResponse profileImage;
+
+    @Schema(description = "닉네임", example = "우기")
+    private String nickname;
+
+    @Schema(description = "작성한 리뷰 수", example = "62")
+    private Integer numOfReviews;
+
+    @Schema(description = "영향력", example = "250")
+    private Integer influence;
+
+    @Schema(description = "팔로워 수", example = "763")
+    private Integer numOfFollowers;
+
+    @Schema(description = "팔로잉 수", example = "68")
+    private Integer numOfFollowings;
+
+    @Schema(description = "취향 통계 정보")
+    private MemberTasteStatisticsResponse tasteStatistics;
+
+    public static GetMemberProfileInfoResponse from(MemberProfileInfoDto memberProfileInfoDto) {
+        return new GetMemberProfileInfoResponse(
+                memberProfileInfoDto.getId(),
+                new MemberProfileImageResponse(
+                        memberProfileInfoDto.getProfileImageUrl(),
+                        memberProfileInfoDto.getProfileThumbnailImageUrl()
+                ),
+                memberProfileInfoDto.getNickname(),
+                memberProfileInfoDto.getNumOfReviews(),
+                memberProfileInfoDto.getInfluence(),
+                memberProfileInfoDto.getNumOfFollowers(),
+                memberProfileInfoDto.getNumOfFollowings(),
+                new MemberTasteStatisticsResponse(
+                        memberProfileInfoDto.getMostVisitedLocation(),
+                        memberProfileInfoDto.getMostTaggedReviewKeyword() != null ? memberProfileInfoDto.getMostTaggedReviewKeyword().getDescription() : "",
+                        memberProfileInfoDto.getMostEatenFoodCategory() != null ? memberProfileInfoDto.getMostEatenFoodCategory().getName() : ""
+                )
+        );
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    public static class MemberProfileImageResponse {
+
+        @Schema(description = "이미지 url", example = "https://member-profile-image-url")
+        private String imageUrl;
+
+        @Schema(description = "썸네일 이미지 url", example = "https://member-profile-thumbnail-image-url")
+        private String thumbnailImageUrl;
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    private static class MemberTasteStatisticsResponse {
+
+        @Schema(description = "가장 많이 방문한 장소(읍면동)", example = "연남동")
+        private String mostVisitedLocation;
+
+        @Schema(description = "가장 많이 태그된 리뷰 키워드", example = "데이트에 최고")
+        private String mostTaggedReviewKeyword;
+
+        @Schema(description = "가장 많이 먹은 음식 카테고리", example = "한식")
+        private String mostEatenFoodCategory;
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #338

## 🏃‍ Task
-  회원 프로필 정보 조회 API(`GET /api/members/{memberId}/profile`) 구현

## 📄 Reference
- None
