### PR TITLE
회원 프로필 정보 조회 API - 내 정보인지 다른 회원의 정보인지 식별할 수 있도록 응답에 boolean 값 추가

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.controller;
 import com.zelusik.eatery.constant.FoodCategoryValue;
 import com.zelusik.eatery.dto.SliceResponse;
 import com.zelusik.eatery.dto.member.MemberDto;
+import com.zelusik.eatery.dto.member.MemberProfileInfoDto;
 import com.zelusik.eatery.dto.member.request.FavoriteFoodCategoriesUpdateRequest;
 import com.zelusik.eatery.dto.member.request.MemberUpdateRequest;
 import com.zelusik.eatery.dto.member.request.TermsAgreeRequest;
@@ -117,8 +118,12 @@ public class MemberController {
             @ApiResponse(description = "[2000] 전달받은 <code>memberId</code>에 해당하는 회원을 찾을 수 없는 경우", responseCode = "404", content = @Content)
     })
     @GetMapping("/{memberId}/profile")
-    public GetMemberProfileInfoResponse getMemberProfileInfo(@PathVariable Long memberId) {
-        return GetMemberProfileInfoResponse.from(memberService.getMemberProfileInfoById(memberId));
+    public GetMemberProfileInfoResponse getMemberProfileInfo(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long memberId
+    ) {
+        MemberProfileInfoDto memberProfileInfoDto = memberService.getMemberProfileInfoById(memberId);
+        return GetMemberProfileInfoResponse.from(userPrincipal.getMemberId(), memberProfileInfoDto);
     }
 
     @Operation(

--- a/src/main/java/com/zelusik/eatery/dto/member/response/GetMemberProfileInfoResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/member/response/GetMemberProfileInfoResponse.java
@@ -15,6 +15,9 @@ public class GetMemberProfileInfoResponse {
     @Schema(description = "회원 id(PK)", example = "1")
     private Long id;
 
+    @Schema(description = "로그인한 사용자와 조회된 회원이 동일한 회원인지 여부", example = "false")
+    private Boolean isEqualLoginMember;
+
     @Schema(description = "프로필 이미지")
     private MemberProfileImageResponse profileImage;
 
@@ -36,9 +39,10 @@ public class GetMemberProfileInfoResponse {
     @Schema(description = "취향 통계 정보")
     private MemberTasteStatisticsResponse tasteStatistics;
 
-    public static GetMemberProfileInfoResponse from(MemberProfileInfoDto memberProfileInfoDto) {
+    public static GetMemberProfileInfoResponse from(long loginMemberId, MemberProfileInfoDto memberProfileInfoDto) {
         return new GetMemberProfileInfoResponse(
                 memberProfileInfoDto.getId(),
+                loginMemberId == memberProfileInfoDto.getId(),
                 new MemberProfileImageResponse(
                         memberProfileInfoDto.getProfileImageUrl(),
                         memberProfileInfoDto.getProfileThumbnailImageUrl()

--- a/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
@@ -178,6 +178,7 @@ class MemberControllerTest {
     @Test
     void given_whenGettingMemberProfileInfoWithMemberId_thenReturnMemberProfileInfo() throws Exception {
         // given
+        long loginMemberId = 1L;
         long memberId = 2L;
         int numOfReviews = 62;
         String mostVisitedLocation = "연남동";
@@ -189,10 +190,11 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         get("/api/members/" + memberId + "/profile")
-                                .with(user(createTestUserDetails(1L)))
+                                .with(user(createTestUserDetails(loginMemberId)))
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(expectedResult.getId()))
+                .andExpect(jsonPath("$.isEqualLoginMember").value(loginMemberId == memberId))
                 .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getProfileImageUrl()))
                 .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getProfileThumbnailImageUrl()))
                 .andExpect(jsonPath("$.nickname").value(expectedResult.getNickname()))


### PR DESCRIPTION
## 🔥 Related Issue
- Close #348 

## 🏃‍ Task
- 회원 프로필 정보 조회 API - 내 정보인지 다른 회원의 정보인지 식별할 수 있도록 응답에 boolean 값 추가

## 📄 Reference
- None
