### PR TITLE
선호 음식 카테고리 변경 API - 요청 시 음식 카테고리를 enum class의 name 값으로 전달받도록 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MemberController.java
@@ -172,14 +172,12 @@ public class MemberController {
             security = @SecurityRequirement(name = "access-token")
     )
     @PutMapping("/favorite-food")
-    public MemberResponse updateFavoriteFoodCategories(
+    public UpdateFavoriteFoodCategoriesResponse updateFavoriteFoodCategories(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody FavoriteFoodCategoriesUpdateRequest request
     ) {
-        List<FoodCategoryValue> favoriteFoodCategories = request.getFavoriteFoodCategories().stream()
-                .map(FoodCategoryValue::valueOfDescription)
-                .toList();
-        return MemberResponse.from(memberService.updateFavoriteFoodCategories(userPrincipal.getMemberId(), favoriteFoodCategories));
+        MemberDto updatedMemberDto = memberService.updateFavoriteFoodCategories(userPrincipal.getMemberId(), request.getFavoriteFoodCategories());
+        return UpdateFavoriteFoodCategoriesResponse.from(updatedMemberDto);
     }
 
     @Operation(

--- a/src/main/java/com/zelusik/eatery/dto/member/request/FavoriteFoodCategoriesUpdateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/member/request/FavoriteFoodCategoriesUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.zelusik.eatery.dto.member.request;
 
+import com.zelusik.eatery.constant.FoodCategoryValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -9,16 +10,11 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FavoriteFoodCategoriesUpdateRequest {
 
-    @Schema(description = "좋아하는 음식 카테고리 목록", example = "[\"한식\", \"일식\", \"디저트\"]")
     @NotNull
-    private List<String> favoriteFoodCategories;
-
-    public static FavoriteFoodCategoriesUpdateRequest of(List<String> favoriteFoodCategories) {
-        return new FavoriteFoodCategoriesUpdateRequest(favoriteFoodCategories);
-    }
+    private List<FoodCategoryValue> favoriteFoodCategories;
 }

--- a/src/main/java/com/zelusik/eatery/dto/member/response/UpdateFavoriteFoodCategoriesResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/member/response/UpdateFavoriteFoodCategoriesResponse.java
@@ -1,0 +1,81 @@
+package com.zelusik.eatery.dto.member.response;
+
+import com.zelusik.eatery.constant.FoodCategoryValue;
+import com.zelusik.eatery.constant.member.RoleType;
+import com.zelusik.eatery.dto.file.response.ImageResponse;
+import com.zelusik.eatery.dto.member.MemberDto;
+import com.zelusik.eatery.dto.member.MemberProfileInfoDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class UpdateFavoriteFoodCategoriesResponse {
+
+    @Schema(description = "PK of member", example = "1")
+    private Long id;
+
+    @Schema(description = "프로필 이미지")
+    private MemberProfileImageResponse profileImage;
+
+    @Schema(description = "닉네임", example = "우기")
+    private String nickname;
+
+    @Schema(description = "성별", example = "남성")
+    private String gender;
+
+    @Schema(description = "생년월일", example = "1998-01-05")
+    private LocalDate birthDay;
+
+    @Schema(description = "수정된 선호 음식 카테고리 목록")
+    private List<FoodCategoryResponse> favoriteFoodCategories;
+
+    public static UpdateFavoriteFoodCategoriesResponse from(MemberDto memberDto) {
+        return new UpdateFavoriteFoodCategoriesResponse(
+                memberDto.getId(),
+                new MemberProfileImageResponse(memberDto.getProfileImageUrl(), memberDto.getProfileThumbnailImageUrl()),
+                memberDto.getNickname(),
+                memberDto.getGender().getDescription(),
+                memberDto.getBirthDay(),
+                memberDto.getFavoriteFoodCategories().stream()
+                        .map(FoodCategoryResponse::from)
+                        .toList()
+        );
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    private static class MemberProfileImageResponse {
+
+        @Schema(description = "이미지 url", example = "https://member-profile-image-url")
+        private String imageUrl;
+
+        @Schema(description = "썸네일 이미지 url", example = "https://member-profile-thumbnail-image-url")
+        private String thumbnailImageUrl;
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    private static class FoodCategoryResponse {
+
+        @Schema(description = "value of food category", example = "KOREAN")
+        private String value;
+
+        @Schema(description = "카테고리 이름", example = "한식")
+        private String categoryName;
+
+        private static FoodCategoryResponse from(FoodCategoryValue foodCategoryValue) {
+            return new FoodCategoryResponse(foodCategoryValue.name(), foodCategoryValue.getCategoryName());
+        }
+    }
+}

--- a/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
@@ -256,7 +256,7 @@ class MemberControllerTest {
     void givenFavoriteFoodCategories_whenUpdatingFavoriteFoodCategories_thenReturnUpdatedMember() throws Exception {
         // given
         long memberId = 1L;
-        FavoriteFoodCategoriesUpdateRequest request = FavoriteFoodCategoriesUpdateRequest.of(List.of("한식", "양식"));
+        FavoriteFoodCategoriesUpdateRequest request = new FavoriteFoodCategoriesUpdateRequest(List.of(FoodCategoryValue.KOREAN, FoodCategoryValue.WESTERN));
         given(memberService.updateFavoriteFoodCategories(any(), any())).willReturn(createMemberDto(memberId));
 
         // when & then


### PR DESCRIPTION
## 🔥 Related Issue
- Close #351

## 🏃‍ Task
- 선호 음식 카테고리 변경 API - 요청 시 음식 카테고리를 enum class의 name 값으로 전달받도록 변경

## 📄 Reference
- None
