### PR TITLE
리뷰 피드 조회 기능 구현

### DIFF
--- a/src/main/java/com/zelusik/eatery/constant/FoodCategoryValue.java
+++ b/src/main/java/com/zelusik/eatery/constant/FoodCategoryValue.java
@@ -54,14 +54,4 @@ public enum FoodCategoryValue {
                 .findFirst()
                 .orElseThrow();
     }
-
-    public static FoodCategoryValue valueOfDescription(String description) {
-        String trimmedDescription = description.replace(" ", "");
-
-        return Arrays.stream(values())
-                .filter(value -> trimmedDescription.equals(
-                        value.getCategoryName().replace(" ", "")
-                )).findFirst()
-                .orElseThrow(NotAcceptableFoodCategory::new);
-    }
 }

--- a/src/main/java/com/zelusik/eatery/controller/ReviewController.java
+++ b/src/main/java/com/zelusik/eatery/controller/ReviewController.java
@@ -132,14 +132,20 @@ public class ReviewController {
     }
 
     @Operation(
-            summary = "피드 조회",
-            description = "<p>피드에 보여줄 리뷰 목록을 조회합니다." +
-                          "<p>모든 리뷰를 최신순으로 보여줍니다." +
-                          "<p>추후 기획 단계에서 고안된 알고리즘에 의해 정렬하여 제공할 예정입니다. (현재는 미구현) 다만, 요청/응답 데이터의 변경은 없을 예정",
+            summary = "리뷰 피드 조회",
+            description = """
+                    <p>리뷰 피드를 조회합니다.
+                    <p>내가 작성한 리뷰는 노출되지 않습니다.
+                    <p>정렬 기준은 다음과 같습니다.
+                    <ol>
+                        <li>리뷰를 작성한 장소의 카테고리가 내가 선호하는 음식 카테고리에 해당되는 경우</li>
+                        <li>최근 등록된 순서</li>
+                    </ol>
+                    """,
             security = @SecurityRequirement(name = "access-token")
     )
     @GetMapping("/feed")
-    public SliceResponse<FeedResponse> searchFeed(
+    public SliceResponse<FindReviewFeedResponse> findReviewFeed(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "페이지 번호 (0부터 시작합니다). 기본값은 0입니다.",
@@ -150,9 +156,8 @@ public class ReviewController {
                     example = "15"
             ) @RequestParam(required = false, defaultValue = "15") int size
     ) {
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        return new SliceResponse<FeedResponse>()
-                .from(reviewService.findDtosOrderByCreatedAt(userPrincipal.getMemberId(), pageRequest).map(FeedResponse::from));
+        Slice<ReviewDto> reviewDtos = reviewService.findReviewReed(userPrincipal.getMemberId(), PageRequest.of(page, size));
+        return new SliceResponse<FindReviewFeedResponse>().from(reviewDtos.map(FindReviewFeedResponse::from));
     }
 
     // TODO: 메뉴 태그 정보가 담긴 ReviewResponse를 응답 객체로 사용할 것인지 검토 필요

--- a/src/main/java/com/zelusik/eatery/dto/review/ReviewDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/ReviewDto.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.zelusik.eatery.constant.review.ReviewEmbedOption.PLACE;
@@ -30,9 +31,10 @@ public class ReviewDto {
     private String autoCreatedContent;
     private String content;
     private List<ReviewImageDto> reviewImageDtos;
+    private LocalDateTime createdAt;
 
     public ReviewDto(PlaceDto place, List<ReviewKeywordValue> keywords, String autoCreatedContent, String content) {
-        this(null, null, place, keywords, autoCreatedContent, content, null);
+        this(null, null, place, keywords, autoCreatedContent, content, null, null);
     }
 
     public static ReviewDto from(Review entity, Boolean isMarkedPlace) {
@@ -53,7 +55,8 @@ public class ReviewDto {
                 entity.getKeywords().stream().map(ReviewKeyword::getKeyword).toList(),
                 entity.getAutoCreatedContent(),
                 entity.getContent(),
-                entity.getReviewImages().stream().map(ReviewImageDto::from).toList()
+                entity.getReviewImages().stream().map(ReviewImageDto::from).toList(),
+                entity.getCreatedAt()
         );
     }
 

--- a/src/main/java/com/zelusik/eatery/dto/review/response/FindReviewFeedResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/response/FindReviewFeedResponse.java
@@ -1,18 +1,21 @@
 package com.zelusik.eatery.dto.review.response;
 
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
-import com.zelusik.eatery.dto.file.response.ImageResponse;
 import com.zelusik.eatery.dto.member.response.MemberResponse;
 import com.zelusik.eatery.dto.place.response.PlaceCompactResponse;
 import com.zelusik.eatery.dto.review.ReviewDto;
+import com.zelusik.eatery.dto.review.ReviewImageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class FindReviewFeedResponse {
 
@@ -32,14 +35,13 @@ public class FindReviewFeedResponse {
     private String content;
 
     @Schema(description = "리뷰 대표 이미지")
-    private ImageResponse reviewImage;
+    private ReviewImageResponse reviewImage;
 
-    public static FindReviewFeedResponse of(Long id, MemberResponse writer, PlaceCompactResponse place, List<String> keywords, String content, ImageResponse reviewImage) {
-        return new FindReviewFeedResponse(id, writer, place, keywords, content, reviewImage);
-    }
+    @Schema(description = "리뷰 작성 시간", example = "2023-09-01T08:01:58.253461")
+    private LocalDateTime createdAt;
 
     public static FindReviewFeedResponse from(ReviewDto dto) {
-        return of(
+        return new FindReviewFeedResponse(
                 dto.getId(),
                 MemberResponse.from(dto.getWriter()),
                 PlaceCompactResponse.from(dto.getPlace()),
@@ -47,7 +49,27 @@ public class FindReviewFeedResponse {
                         .map(ReviewKeywordValue::getDescription)
                         .toList(),
                 dto.getContent(),
-                ImageResponse.of(dto.getReviewImageDtos().get(0).getUrl(), dto.getReviewImageDtos().get(0).getThumbnailUrl())
+                new ReviewImageResponse(dto.getReviewImageDtos().get(0).getUrl(), dto.getReviewImageDtos().get(0).getThumbnailUrl()),
+                dto.getCreatedAt()
         );
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    private static class ReviewImageResponse {
+
+        @Schema(description = "이미지 url", example = "https://review-image-url")
+        private String url;
+
+        @Schema(description = "썸네일 이미지 url", example = "https//review-thumbnail-image-url")
+        private String thumbnailUrl;
+
+        private static ReviewImageResponse from(ReviewImageDto dto) {
+            return new ReviewImageResponse(
+                    dto.getUrl(),
+                    dto.getThumbnailUrl()
+            );
+        }
     }
 }

--- a/src/main/java/com/zelusik/eatery/dto/review/response/FindReviewFeedResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/review/response/FindReviewFeedResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class FeedResponse {
+public class FindReviewFeedResponse {
 
     @Schema(description = "리뷰 id(PK)", example = "1")
     private Long id;
@@ -34,11 +34,11 @@ public class FeedResponse {
     @Schema(description = "리뷰 대표 이미지")
     private ImageResponse reviewImage;
 
-    public static FeedResponse of(Long id, MemberResponse writer, PlaceCompactResponse place, List<String> keywords, String content, ImageResponse reviewImage) {
-        return new FeedResponse(id, writer, place, keywords, content, reviewImage);
+    public static FindReviewFeedResponse of(Long id, MemberResponse writer, PlaceCompactResponse place, List<String> keywords, String content, ImageResponse reviewImage) {
+        return new FindReviewFeedResponse(id, writer, place, keywords, content, reviewImage);
     }
 
-    public static FeedResponse from(ReviewDto dto) {
+    public static FindReviewFeedResponse from(ReviewDto dto) {
         return of(
                 dto.getId(),
                 MemberResponse.from(dto.getWriter()),

--- a/src/main/java/com/zelusik/eatery/repository/review/ReviewRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/repository/review/ReviewRepositoryQCustom.java
@@ -20,4 +20,19 @@ public interface ReviewRepositoryQCustom {
      * @return 조회된 리뷰 목록(Slice)
      */
     Slice<ReviewDto> findDtos(Long loginMemberId, Long writerId, Long placeId, List<ReviewEmbedOption> embed, Pageable pageable);
+
+    /**
+     * <p>리뷰 피드를 조회한다.
+     * <p>내가 작성한 리뷰는 노출되지 않는다.
+     * <p>정렬 기준은 다음과 같다.
+     * <ol>
+     *     <li>리뷰를 작성한 장소의 카테고리가 내가 선호하는 음식 카테고리에 해당되는 경우</li>
+     *     <li>최근 등록된 순서</li>
+     * </ol>
+     *
+     * @param loginMemberId PK of login member
+     * @param pageable      paging 정보
+     * @return 조회된 리뷰 dtos
+     */
+    Slice<ReviewDto> findReviewFeed(long loginMemberId, Pageable pageable);
 }

--- a/src/main/java/com/zelusik/eatery/repository/review/ReviewRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/review/ReviewRepositoryQCustomImpl.java
@@ -1,13 +1,16 @@
 package com.zelusik.eatery.repository.review;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zelusik.eatery.constant.review.ReviewEmbedOption;
 import com.zelusik.eatery.domain.QBookmark;
+import com.zelusik.eatery.domain.member.FavoriteFoodCategory;
 import com.zelusik.eatery.domain.review.Review;
 import com.zelusik.eatery.dto.review.ReviewDto;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +19,11 @@ import org.springframework.data.domain.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static com.zelusik.eatery.constant.review.ReviewEmbedOption.PLACE;
+import static com.zelusik.eatery.constant.review.ReviewEmbedOption.WRITER;
+import static com.zelusik.eatery.domain.member.QFavoriteFoodCategory.favoriteFoodCategory;
 import static com.zelusik.eatery.domain.member.QMember.member;
 import static com.zelusik.eatery.domain.place.QPlace.place;
 import static com.zelusik.eatery.domain.review.QReview.review;
@@ -31,8 +37,8 @@ public class ReviewRepositoryQCustomImpl implements ReviewRepositoryQCustom {
     public Slice<ReviewDto> findDtos(Long loginMemberId, Long writerId, Long placeId, List<ReviewEmbedOption> embed, Pageable pageable) {
         List<Predicate> conditions = new ArrayList<>();
         conditions.add(isNotDeleted());
-        conditions.add(writerFilteringCondition(writerId));
-        conditions.add(placeFilteringCondition(placeId));
+        conditions.add(writerEqualFilteringCondition(writerId));
+        conditions.add(placeEqualFilteringCondition(placeId));
 
         List<ReviewDto> content = new ArrayList<>();
         if (embed.contains(PLACE)) {
@@ -77,6 +83,67 @@ public class ReviewRepositoryQCustomImpl implements ReviewRepositoryQCustom {
         return new SliceImpl<>(content, PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Order.desc("createdAt"))), hasNext);
     }
 
+    @Override
+    public Slice<ReviewDto> findReviewFeed(long loginMemberId, Pageable pageable) {
+        List<FavoriteFoodCategory> favoriteFoodCategories = queryFactory
+                .selectFrom(favoriteFoodCategory)
+                .where(favoriteFoodCategory.member.id.eq(loginMemberId))
+                .fetch();
+
+        List<Tuple> tuples = queryFactory
+                .select(review, isMarkedPlace(loginMemberId))
+                .from(review)
+                .join(review.writer, member).fetchJoin()
+                .join(review.place, place).fetchJoin()
+                .where(isNotDeleted(),
+                        member.id.ne(loginMemberId))    // 내가 작성한 리뷰는 보이지 않아야 함
+                .orderBy(matchFavoriteFoodCategories(favoriteFoodCategories),
+                        review.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        List<ReviewDto> content = tuples.stream()
+                .map(tuple -> ReviewDto.from(
+                        Objects.requireNonNull(tuple.get(review)),
+                        List.of(WRITER, PLACE),
+                        Boolean.TRUE.equals(tuple.get(isMarkedPlace(loginMemberId)))
+                )).collect(Collectors.toList());
+
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(
+                content,
+                PageRequest.of(
+                        pageable.getPageNumber(),
+                        pageable.getPageSize(),
+                        Sort.by(Sort.Order.asc("isFavoriteFoodCategoryOfReview"),
+                                Sort.Order.desc("createdAt"))
+                ),
+                hasNext
+        );
+    }
+
+    /**
+     * 장소의 firstCategory가 회원의 선호 음식 카테고리(favoriteFoodCategories)에 해당할 때 더 높은 우선순위를 갖도록 설정한다.
+     *
+     * @param favoriteFoodCategories 회원의 선호 음식 카테고리 목록
+     * @return 정렬 정보(OrderSpecifier)
+     */
+    private OrderSpecifier<Integer> matchFavoriteFoodCategories(List<FavoriteFoodCategory> favoriteFoodCategories) {
+        List<String> favoritePlaceFirstCategories = favoriteFoodCategories.stream()
+                .flatMap(foodCategory -> foodCategory.getCategory().getMatchingFirstCategories().stream())
+                .toList();
+        return new CaseBuilder()
+                .when(place.category.firstCategory.in(favoritePlaceFirstCategories)).then(1)
+                .otherwise(2)
+                .asc();
+    }
+
     private static JPQLQuery<Boolean> isMarkedPlace(Long loginMemberId) {
         QBookmark subBookmark = new QBookmark("bookmark");
         return JPAExpressions
@@ -90,11 +157,11 @@ public class ReviewRepositoryQCustomImpl implements ReviewRepositoryQCustom {
         return review.deletedAt.isNull();
     }
 
-    private BooleanExpression writerFilteringCondition(Long writerId) {
+    private BooleanExpression writerEqualFilteringCondition(Long writerId) {
         return writerId != null ? member.id.eq(writerId) : null;
     }
 
-    private BooleanExpression placeFilteringCondition(Long placeId) {
+    private BooleanExpression placeEqualFilteringCondition(Long placeId) {
         return placeId != null ? place.id.eq(placeId) : null;
     }
 }

--- a/src/main/java/com/zelusik/eatery/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/service/ReviewService.java
@@ -116,6 +116,7 @@ public class ReviewService {
     /**
      * <p>리뷰 목록 조회.
      * <p>장소에 대한 정보는 <code>null</code>로 처리하여 반환합니다. (query 최적화)
+     * <p>정렬 기준은 최근 등록된 순서입니다.
      *
      * @param loginMemberId PK of login member
      * @param writerId      filter - 특정 회원이 작성한 리뷰만 조회
@@ -129,17 +130,6 @@ public class ReviewService {
     }
 
     /**
-     * 전체 리뷰 조회. 최신순 정렬
-     *
-     * @param pageable paging 정보
-     * @return 조회된 리뷰 목록(slice)
-     */
-    public Slice<ReviewDto> findDtosOrderByCreatedAt(Long memberId, Pageable pageable) {
-        return reviewRepository.findAllByDeletedAtNull(pageable)
-                .map(review -> ReviewDto.from(review, bookmarkService.isMarkedPlace(memberId, review.getPlace())));
-    }
-
-    /**
      * 특정 회원이 작성한 리뷰 조회.
      *
      * @param writerId 작성자의 PK
@@ -149,6 +139,23 @@ public class ReviewService {
     public Slice<ReviewDto> findDtosByWriterId(Long writerId, Pageable pageable) {
         return reviewRepository.findByWriter_IdAndDeletedAtNull(writerId, pageable)
                 .map(review -> ReviewDto.from(review, bookmarkService.isMarkedPlace(writerId, review.getPlace())));
+    }
+
+    /**
+     * <p>리뷰 피드를 조회한다.
+     * <p>내가 작성한 리뷰는 노출되지 않는다.
+     * <p>정렬 기준은 다음과 같다.
+     * <ol>
+     *     <li>리뷰를 작성한 장소의 카테고리가 내가 선호하는 음식 카테고리에 해당되는 경우</li>
+     *     <li>최근 등록된 순서</li>
+     * </ol>
+     *
+     * @param loginMemberId PK of login member
+     * @param pageable      paging 정보
+     * @return 조회된 리뷰 dtos
+     */
+    public Slice<ReviewDto> findReviewReed(long loginMemberId, Pageable pageable) {
+        return reviewRepository.findReviewFeed(loginMemberId, pageable);
     }
 
     /**

--- a/src/test/java/com/zelusik/eatery/unit/controller/RecommendedReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/RecommendedReviewControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -216,7 +217,8 @@ class RecommendedReviewControllerTest {
                 List.of(ReviewKeywordValue.NOISY, ReviewKeywordValue.FRESH),
                 "자동 생성된 내용",
                 "제출된 내용",
-                List.of(createReviewImageDto(100L, reviewId))
+                List.of(createReviewImageDto(100L, reviewId)),
+                LocalDateTime.now()
         );
     }
 

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -160,7 +160,7 @@ class ReviewControllerTest {
         long loginMemberId = 1L;
         long reviewId = 2L;
         Slice<ReviewDto> expectedResult = new SliceImpl<>(List.of(createReviewDto(reviewId, createMemberDto(3L), createPlaceDto(4L))));
-        given(reviewService.findDtosOrderByCreatedAt(eq(loginMemberId), any(Pageable.class))).willReturn(expectedResult);
+        given(reviewService.findReviewReed(eq(loginMemberId), any(Pageable.class))).willReturn(expectedResult);
 
         // when & then
         mvc.perform(get("/api/reviews/feed")
@@ -170,7 +170,7 @@ class ReviewControllerTest {
                 .andExpect(jsonPath("$.contents[0].id").value(reviewId))
                 .andExpect(jsonPath("$.contents[0].reviewImage").exists())
                 .andDo(print());
-        then(reviewService).should().findDtosOrderByCreatedAt(eq(loginMemberId), any(Pageable.class));
+        then(reviewService).should().findReviewReed(eq(loginMemberId), any(Pageable.class));
         then(reviewService).shouldHaveNoMoreInteractions();
     }
 

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -39,6 +39,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -315,7 +316,8 @@ class ReviewControllerTest {
                         "storedName",
                         "url",
                         "thumbnailStoredName",
-                        "thumbnailUrl"))
+                        "thumbnailUrl")),
+                LocalDateTime.now()
         );
     }
 

--- a/src/test/java/com/zelusik/eatery/unit/service/RecommendedReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/RecommendedReviewServiceTest.java
@@ -256,7 +256,8 @@ class RecommendedReviewServiceTest {
                         "storedName",
                         "url",
                         "thumbnailStoredName",
-                        "thumbnailUrl"))
+                        "thumbnailUrl")),
+                LocalDateTime.now()
         );
     }
 

--- a/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
@@ -418,7 +418,8 @@ class ReviewServiceTest {
                         "storedName",
                         "url",
                         "thumbnailStoredName",
-                        "thumbnailUrl"))
+                        "thumbnailUrl")),
+                LocalDateTime.now()
         );
     }
 

--- a/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
@@ -1,19 +1,35 @@
 package com.zelusik.eatery.unit.service;
 
+import com.zelusik.eatery.constant.ConstantUtil;
+import com.zelusik.eatery.constant.FoodCategoryValue;
+import com.zelusik.eatery.constant.member.Gender;
+import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
+import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.member.Member;
+import com.zelusik.eatery.domain.place.Address;
 import com.zelusik.eatery.domain.place.Place;
+import com.zelusik.eatery.domain.place.PlaceCategory;
+import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.domain.review.Review;
+import com.zelusik.eatery.domain.review.ReviewImage;
 import com.zelusik.eatery.domain.review.ReviewKeyword;
+import com.zelusik.eatery.dto.member.MemberDto;
+import com.zelusik.eatery.dto.place.PlaceDto;
 import com.zelusik.eatery.dto.review.ReviewDto;
+import com.zelusik.eatery.dto.review.ReviewImageDto;
+import com.zelusik.eatery.dto.review.request.MenuTagPointCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewCreateRequest;
+import com.zelusik.eatery.dto.review.request.ReviewImageCreateRequest;
+import com.zelusik.eatery.dto.review.request.ReviewMenuTagCreateRequest;
 import com.zelusik.eatery.exception.review.ReviewDeletePermissionDeniedException;
 import com.zelusik.eatery.exception.review.ReviewNotFoundException;
 import com.zelusik.eatery.repository.review.ReviewImageMenuTagRepository;
 import com.zelusik.eatery.repository.review.ReviewKeywordRepository;
 import com.zelusik.eatery.repository.review.ReviewRepository;
 import com.zelusik.eatery.service.*;
-import com.zelusik.eatery.util.ReviewTestUtils;
+import com.zelusik.eatery.util.MultipartFileTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,16 +40,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.zelusik.eatery.constant.review.ReviewEmbedOption.PLACE;
 import static com.zelusik.eatery.constant.review.ReviewEmbedOption.WRITER;
-import static com.zelusik.eatery.util.MemberTestUtils.createMember;
-import static com.zelusik.eatery.util.MemberTestUtils.createMemberDto;
-import static com.zelusik.eatery.util.PlaceTestUtils.createPlace;
-import static com.zelusik.eatery.util.ReviewKeywordTestUtils.createReviewKeyword;
-import static com.zelusik.eatery.util.ReviewTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,13 +85,17 @@ class ReviewServiceTest {
         String kakaoPid = "12345";
         Place expectedPlace = createPlace(placeId, kakaoPid);
         Member expectedMember = createMember(writerId);
-        Review createdReview = createReviewWithKeywordsAndImages(3L, expectedMember, expectedPlace);
+        Review createdReview = createReview(3L, expectedMember, expectedPlace);
+        ReviewKeyword reviewKeyword = createReviewKeyword(4L, createdReview, ReviewKeywordValue.FRESH);
+        createdReview.getKeywords().add(reviewKeyword);
+        ReviewImage reviewImage = createReviewImage(100L, createdReview);
+        createdReview.getReviewImages().add(reviewImage);
         given(placeService.findById(placeId)).willReturn(expectedPlace);
         given(memberService.findById(writerId)).willReturn(expectedMember);
         given(bookmarkService.isMarkedPlace(writerId, expectedPlace)).willReturn(false);
         given(reviewRepository.save(any(Review.class))).willReturn(createdReview);
-        given(reviewKeywordRepository.save(any(ReviewKeyword.class))).willReturn(createReviewKeyword(4L, createdReview, ReviewKeywordValue.FRESH));
-        given(reviewImageService.upload(any(Review.class), any())).willReturn(List.of(createReviewImage(100L, createdReview)));
+        given(reviewKeywordRepository.save(any(ReviewKeyword.class))).willReturn(reviewKeyword);
+        given(reviewImageService.upload(any(Review.class), any())).willReturn(List.of(reviewImage));
         given(reviewImageMenuTagRepository.saveAll(anyList())).willReturn(List.of());
         willDoNothing().given(placeService).renewTop3Keywords(expectedPlace);
 
@@ -103,7 +121,7 @@ class ReviewServiceTest {
         // given
         long memberId = 1L;
         long reviewId = 2L;
-        Review expectedResult = createReview(reviewId, memberId, 3L, "12345", 4L, 5L);
+        Review expectedResult = createReview(reviewId, createMember(memberId), createPlace(3L, "12345"));
         given(reviewRepository.findByIdAndDeletedAtNull(reviewId)).willReturn(Optional.of(expectedResult));
 
         // when
@@ -139,7 +157,7 @@ class ReviewServiceTest {
         // given
         long memberId = 1L;
         long reviewId = 2L;
-        Review expectedResult = createReview(reviewId, memberId, 3L, "12345", 4L, 5L);
+        Review expectedResult = createReview(reviewId, createMember(memberId), createPlace(3L, "12345"));
         given(reviewRepository.findByIdAndDeletedAtNull(reviewId)).willReturn(Optional.of(expectedResult));
         given(bookmarkService.isMarkedPlace(eq(memberId), any(Place.class))).willReturn(false);
 
@@ -161,7 +179,9 @@ class ReviewServiceTest {
         // given
         long loginMemberId = 1L;
         Pageable pageable = Pageable.ofSize(15);
-        Slice<ReviewDto> expectedSearchResult = new SliceImpl<>(List.of(ReviewTestUtils.createReviewDto(2L, createMemberDto(3L))));
+        MemberDto member = createMemberDto(3L);
+        PlaceDto place = createPlaceDto(4L, "12345");
+        Slice<ReviewDto> expectedSearchResult = new SliceImpl<>(List.of(createReviewDto(2L, member, place)));
         given(reviewRepository.findDtos(loginMemberId, null, null, List.of(WRITER, PLACE), pageable)).willReturn(expectedSearchResult);
 
         // when
@@ -179,7 +199,7 @@ class ReviewServiceTest {
         // given
         long writerId = 2L;
         Pageable pageable = Pageable.ofSize(15);
-        SliceImpl<Review> expectedSearchResult = new SliceImpl<>(List.of(ReviewTestUtils.createReview(1L, writerId, 3L, "3", 4L, 5L)));
+        SliceImpl<Review> expectedSearchResult = new SliceImpl<>(List.of(createReview(1L, createMember(writerId), createPlace(3L, "12345"))));
         given(reviewRepository.findByWriter_IdAndDeletedAtNull(writerId, pageable)).willReturn(expectedSearchResult);
         given(bookmarkService.isMarkedPlace(eq(writerId), any(Place.class))).willReturn(false);
 
@@ -193,6 +213,27 @@ class ReviewServiceTest {
         assertThat(actualSearchResult.hasContent()).isTrue();
     }
 
+    @DisplayName("리뷰 피드를 조회한다.")
+    @Test
+    void given_whenFindReviewFeed_thenReturnResults() {
+        // given
+        long loginMemberId = 1L;
+        long reviewId = 2L;
+        Pageable pageable = Pageable.ofSize(10);
+        MemberDto writer = createMemberDto(3L);
+        PlaceDto place = createPlaceDto(4L, "123");
+        Slice<ReviewDto> expectedResults = new SliceImpl<>(List.of(createReviewDto(reviewId, writer, place)), pageable, false);
+        given(reviewRepository.findReviewFeed(loginMemberId, pageable)).willReturn(expectedResults);
+
+        // when
+        Slice<ReviewDto> actualResults = sut.findReviewReed(loginMemberId, Pageable.ofSize(10));
+
+        // then
+        then(reviewRepository).should().findReviewFeed(loginMemberId, pageable);
+        verifyEveryMocksShouldHaveNoMoreInteractions();
+        assertThat(actualResults).hasSize(expectedResults.getNumberOfElements());
+    }
+
     @DisplayName("리뷰를 삭제하면, 리뷰와 모든 리뷰 이미지들을 soft delete하고 모든 리뷰 키워드들을 삭제한다.")
     @Test
     void given_whenSoftDeleteReview_thenSoftDeleteReviewAndAllReviewImagesAndDeleteAllReviewKeywords() {
@@ -201,7 +242,11 @@ class ReviewServiceTest {
         long reviewId = 3L;
         Member loginMember = createMember(memberId);
         Place place = createPlace(2L, "2");
-        Review findReview = createReviewWithKeywordsAndImages(reviewId, loginMember, place);
+        Review findReview = createReview(reviewId, loginMember, place);
+        ReviewKeyword reviewKeyword = createReviewKeyword(5L, findReview, ReviewKeywordValue.FRESH);
+        findReview.getKeywords().add(reviewKeyword);
+        ReviewImage reviewImage = createReviewImage(6L, findReview);
+        findReview.getReviewImages().add(reviewImage);
         given(memberService.findById(memberId)).willReturn(loginMember);
         given(reviewRepository.findByIdAndDeletedAtNull(reviewId)).willReturn(Optional.of(findReview));
         willDoNothing().given(reviewImageService).softDeleteAll(findReview.getReviewImages());
@@ -232,7 +277,11 @@ class ReviewServiceTest {
         Place place = createPlace(4L, "2");
         Member loginMember = createMember(loginMemberId);
         Member reviewWriter = createMember(reviewWriterId);
-        Review findReview = createReviewWithKeywordsAndImages(reviewId, reviewWriter, place);
+        Review findReview = createReview(reviewId, reviewWriter, place);
+        ReviewKeyword reviewKeyword = createReviewKeyword(5L, findReview, ReviewKeywordValue.FRESH);
+        findReview.getKeywords().add(reviewKeyword);
+        ReviewImage reviewImage = createReviewImage(6L, findReview);
+        findReview.getReviewImages().add(reviewImage);
         given(memberService.findById(loginMemberId)).willReturn(loginMember);
         given(reviewRepository.findByIdAndDeletedAtNull(reviewId)).willReturn(Optional.of(findReview));
 
@@ -253,5 +302,172 @@ class ReviewServiceTest {
         then(reviewRepository).shouldHaveNoMoreInteractions();
         then(reviewKeywordRepository).shouldHaveNoMoreInteractions();
         then(bookmarkService).shouldHaveNoMoreInteractions();
+    }
+
+    private Member createMember(Long memberId) {
+        return createMember(memberId, Set.of(RoleType.USER));
+    }
+
+    private Member createMember(Long memberId, Set<RoleType> roleTypes) {
+        return Member.of(
+                memberId,
+                null,
+                "profile image url",
+                "profile thunmbnail image url",
+                "social user id",
+                LoginType.KAKAO,
+                roleTypes,
+                "email",
+                "nickname",
+                LocalDate.of(2000, 1, 1),
+                20,
+                Gender.MALE,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    private MemberDto createMemberDto(Long memberId) {
+        return createMemberDto(memberId, Set.of(RoleType.USER));
+    }
+
+    private MemberDto createMemberDto(Long memberId, Set<RoleType> roleTypes) {
+        return new MemberDto(
+                memberId,
+                null,
+                ConstantUtil.defaultProfileImageUrl,
+                ConstantUtil.defaultProfileThumbnailImageUrl,
+                "1234567890",
+                LoginType.KAKAO,
+                roleTypes,
+                "test@test.com",
+                "test",
+                LocalDate.of(1998, 1, 5),
+                20,
+                Gender.MALE,
+                List.of(FoodCategoryValue.KOREAN),
+                null
+        );
+    }
+
+    private Place createPlace(long id, String kakaoPid) {
+        return Place.of(
+                id,
+                List.of(ReviewKeywordValue.FRESH),
+                kakaoPid,
+                "place name",
+                "page url",
+                KakaoCategoryGroupCode.FD6,
+                new PlaceCategory("한식", "냉면", null),
+                null,
+                new Address("sido", "sgg", "lot number address", "road address"),
+                null,
+                new Point("37.5595073462493", "126.921462488105"),
+                "",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    public static PlaceDto createPlaceDto(long placeId, String kakaoPid) {
+        return new PlaceDto(
+                placeId,
+                List.of(ReviewKeywordValue.FRESH),
+                kakaoPid,
+                "연남토마 본점",
+                "http://place.map.kakao.com/308342289",
+                KakaoCategoryGroupCode.FD6,
+                PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
+                "02-332-8064",
+                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                "http://place.map.kakao.com/308342289",
+                new Point("37.5595073462493", "126.921462488105"),
+                null,
+                List.of(),
+                null,
+                false
+        );
+    }
+
+    private Review createReview(Long reviewId, Member member, Place place) {
+        return Review.of(
+                reviewId,
+                member,
+                place,
+                "자동 생성된 내용",
+                "제출한 내용",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    public static ReviewDto createReviewDto(long reviewId, MemberDto writer, PlaceDto place) {
+        return new ReviewDto(
+                reviewId,
+                writer,
+                place,
+                List.of(ReviewKeywordValue.NOISY, ReviewKeywordValue.FRESH),
+                "자동 생성된 내용",
+                "제출된 내용",
+                List.of(new ReviewImageDto(
+                        1L,
+                        1L,
+                        "test.txt",
+                        "storedName",
+                        "url",
+                        "thumbnailStoredName",
+                        "thumbnailUrl"))
+        );
+    }
+
+    private ReviewKeyword createReviewKeyword(Long reviewKeywordId, Review review, ReviewKeywordValue reviewKeywordValue) {
+        return ReviewKeyword.of(
+                reviewKeywordId,
+                review,
+                reviewKeywordValue,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    public static ReviewImage createReviewImage(Long reviewImageId, Review review) {
+        return ReviewImage.of(
+                reviewImageId,
+                review,
+                "original file name",
+                "stored file name",
+                "url",
+                "thumbnail stored file name",
+                "thumbnail url",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    private ReviewCreateRequest createReviewCreateRequest(long placeId) {
+        return ReviewCreateRequest.of(
+                placeId,
+                List.of(ReviewKeywordValue.FRESH),
+                "자동 생성된 내용",
+                "제출한 내용",
+                List.of(createReviewImageCreateRequest())
+        );
+    }
+
+    private ReviewImageCreateRequest createReviewImageCreateRequest() {
+        return new ReviewImageCreateRequest(
+                MultipartFileTestUtils.createMockMultipartFile(),
+                List.of(
+                        createReviewMenuTagCreateRequest("치킨"),
+                        createReviewMenuTagCreateRequest("피자")
+                )
+        );
+    }
+
+    private ReviewMenuTagCreateRequest createReviewMenuTagCreateRequest(String content) {
+        return new ReviewMenuTagCreateRequest(content, new MenuTagPointCreateRequest("10.0", "50.0"));
     }
 }

--- a/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
@@ -6,90 +6,16 @@ import com.zelusik.eatery.domain.place.Place;
 import com.zelusik.eatery.domain.review.Review;
 import com.zelusik.eatery.domain.review.ReviewImage;
 import com.zelusik.eatery.domain.review.ReviewKeyword;
-import com.zelusik.eatery.dto.member.MemberDto;
-import com.zelusik.eatery.dto.review.ReviewDto;
-import com.zelusik.eatery.dto.review.ReviewImageDto;
 import com.zelusik.eatery.dto.review.request.MenuTagPointCreateRequest;
-import com.zelusik.eatery.dto.review.request.ReviewCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewImageCreateRequest;
 import com.zelusik.eatery.dto.review.request.ReviewMenuTagCreateRequest;
-import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.zelusik.eatery.util.MemberTestUtils.createMemberDto;
 import static com.zelusik.eatery.util.ReviewKeywordTestUtils.createReviewKeyword;
 
 public class ReviewTestUtils {
-
-    public static ReviewCreateRequest createReviewCreateRequest(long placeId) {
-        return ReviewCreateRequest.of(
-                placeId,
-                List.of(ReviewKeywordValue.FRESH),
-                "자동 생성된 내용",
-                "제출한 내용",
-                List.of(createReviewImageCreateRequest())
-        );
-    }
-
-    @NotNull
-    public static ReviewImageCreateRequest createReviewImageCreateRequest() {
-        return new ReviewImageCreateRequest(
-                MultipartFileTestUtils.createMockMultipartFile(),
-                List.of(
-                        createReviewMenuTagCreateRequest("치킨"),
-                        createReviewMenuTagCreateRequest("피자")
-                )
-        );
-    }
-
-    public static ReviewDto createReviewDto(long reviewId, MemberDto writer) {
-        return new ReviewDto(
-                reviewId,
-                writer,
-                PlaceTestUtils.createPlaceDto(),
-                List.of(ReviewKeywordValue.NOISY, ReviewKeywordValue.FRESH),
-                "자동 생성된 내용",
-                "제출된 내용",
-                List.of(new ReviewImageDto(
-                        1L,
-                        1L,
-                        "test.txt",
-                        "storedName",
-                        "url",
-                        "thumbnailStoredName",
-                        "thumbnailUrl"))
-        );
-    }
-
-    public static ReviewDto createReviewDto(long reviewId) {
-        return createReviewDto(reviewId, MemberTestUtils.createMemberDto());
-    }
-
-    public static ReviewDto createReviewDto() {
-        return createReviewDto(1L);
-    }
-
-    public static ReviewDto createReviewDtoWithoutPlace() {
-        return new ReviewDto(
-                1L,
-                MemberTestUtils.createMemberDto(),
-                null,
-                List.of(ReviewKeywordValue.NOISY, ReviewKeywordValue.FRESH),
-                "자동 생성된 내용",
-                "제출된 내용",
-                List.of(new ReviewImageDto(
-                        1L,
-                        1L,
-                        "test.txt",
-                        "storedName",
-                        "url",
-                        "thumbnailStoredName",
-                        "thumbnailUrl"
-                ))
-        );
-    }
 
     public static Review createNewReview(Member writer, Place place, List<ReviewKeyword> reviewKeywords) {
         return createReview(null, writer, place, reviewKeywords, List.of());
@@ -97,13 +23,6 @@ public class ReviewTestUtils {
 
     public static Review createNewReview(Member writer, Place place, List<ReviewKeyword> reviewKeywords, List<ReviewImage> reviewImages) {
         return createReview(null, writer, place, reviewKeywords, reviewImages);
-    }
-
-    public static Review createReviewWithKeywordsAndImages(Long reviewId, Member member, Place place) {
-        Review review = createReview(reviewId, member, place);
-        review.getKeywords().add(createReviewKeyword(10L, review, ReviewKeywordValue.BEST_FLAVOR));
-        review.getReviewImages().add(createReviewImage(11L, review));
-        return review;
     }
 
     public static Review createReview(Long reviewId, Long memberId, Long placeId, String kakaoPid, Long reviewKeywordId, Long reviewImageId) {
@@ -152,6 +71,16 @@ public class ReviewTestUtils {
                 LocalDateTime.now(),
                 LocalDateTime.now(),
                 null
+        );
+    }
+
+    public static ReviewImageCreateRequest createReviewImageCreateRequest() {
+        return new ReviewImageCreateRequest(
+                MultipartFileTestUtils.createMockMultipartFile(),
+                List.of(
+                        createReviewMenuTagCreateRequest("치킨"),
+                        createReviewMenuTagCreateRequest("피자")
+                )
         );
     }
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #358 

## 🏃‍ Task
- 리뷰 피드 조회 business logic, query 개선
- 피드 응답 데이터에 작성한 시간 추가
- 추천 로직 적용
  - 리뷰를 작성한 장소의 카테고리가 내가 선호하는 음식 카테고리에 해당되는 경우 우선순위 높도록 설정

## 📄 Reference
- None
