### PR TITLE
필터링 키워드 조회 API repository layer 로직 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/place/Address.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/Address.java
@@ -37,7 +37,7 @@ public class Address {
     @Nullable
     private String roadAddress;
 
-    public Address(String lotNumberAddress, String roadAddress) {
+    public static Address of(String lotNumberAddress, String roadAddress) {
         String address;
         if (StringUtils.hasText(lotNumberAddress)) {
             address = lotNumberAddress;
@@ -48,10 +48,12 @@ public class Address {
         int sidoIdx = address.indexOf(" ");
         int sggIdx = address.indexOf(" ", sidoIdx + 1);
 
-        this.sido = address.substring(0, sidoIdx);
-        this.sgg = address.substring(sidoIdx + 1, sggIdx);
-        this.lotNumberAddress = StringUtils.hasText(lotNumberAddress) ? lotNumberAddress.substring(sggIdx + 1) : null;
-        this.roadAddress = StringUtils.hasText(roadAddress) ? roadAddress.substring(sggIdx + 1) : null;
+        return new Address(
+                address.substring(0, sidoIdx),
+                address.substring(sidoIdx + 1, sggIdx),
+                StringUtils.hasText(lotNumberAddress) ? lotNumberAddress.substring(sggIdx + 1) : null,
+                StringUtils.hasText(roadAddress) ? roadAddress.substring(sggIdx + 1) : null
+        );
     }
 
     @Override
@@ -59,9 +61,9 @@ public class Address {
         if (this == o) return true;
         if (!(o instanceof Address that)) return false;
         return Objects.equals(this.getSido(), that.getSido())
-                && Objects.equals(this.getSgg(), that.getSgg())
-                && Objects.equals(this.getLotNumberAddress(), that.getLotNumberAddress())
-                && Objects.equals(this.getRoadAddress(), that.getRoadAddress());
+               && Objects.equals(this.getSgg(), that.getSgg())
+               && Objects.equals(this.getLotNumberAddress(), that.getLotNumberAddress())
+               && Objects.equals(this.getRoadAddress(), that.getRoadAddress());
     }
 
     @Override

--- a/src/main/java/com/zelusik/eatery/domain/place/OpeningHours.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/OpeningHours.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,10 +40,16 @@ public class OpeningHours extends BaseTimeEntity {
     private LocalTime closeAt;
 
     public static OpeningHours of(Place place, DayOfWeek dayOfWeek, LocalTime openAt, LocalTime closeAt) {
-        return new OpeningHours(place, dayOfWeek, openAt, closeAt);
+        return new OpeningHours(null, place, dayOfWeek, openAt, closeAt, null, null);
     }
 
-    private OpeningHours(Place place, DayOfWeek dayOfWeek, LocalTime openAt, LocalTime closeAt) {
+    public static OpeningHours of(Long id, Place place, DayOfWeek dayOfWeek, LocalTime openAt, LocalTime closeAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new OpeningHours(id, place, dayOfWeek, openAt, closeAt, createdAt, updatedAt);
+    }
+
+    private OpeningHours(Long id, Place place, DayOfWeek dayOfWeek, LocalTime openAt, LocalTime closeAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
         this.place = place;
         this.dayOfWeek = dayOfWeek;
         this.openAt = openAt;

--- a/src/main/java/com/zelusik/eatery/dto/place/PlaceFilteringKeywordDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/place/PlaceFilteringKeywordDto.java
@@ -4,16 +4,14 @@ import com.zelusik.eatery.constant.place.FilteringType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class PlaceFilteringKeywordDto {
 
     private String keyword;
     private Integer count;
     private FilteringType type;
-
-    public static PlaceFilteringKeywordDto of(String keyword, Integer count, FilteringType type) {
-        return new PlaceFilteringKeywordDto(keyword, count, type);
-    }
 }

--- a/src/main/java/com/zelusik/eatery/dto/place/PlaceFilteringKeywordDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/place/PlaceFilteringKeywordDto.java
@@ -6,12 +6,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class PlaceFilteringKeywordDto {
 
     private String keyword;
-    private Integer count;
+    private int count;
     private FilteringType type;
 }

--- a/src/main/java/com/zelusik/eatery/dto/place/request/PlaceCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/dto/place/request/PlaceCreateRequest.java
@@ -66,7 +66,7 @@ public class PlaceCreateRequest {
                 this.getCategoryGroupCode(),
                 PlaceCategory.of(this.getCategoryName()),
                 this.getPhone(),
-                new Address(this.getLotNumberAddress(), this.getRoadAddress()),
+                Address.of(this.getLotNumberAddress(), this.getRoadAddress()),
                 homepageUrl,
                 new Point(this.getLat(), this.getLng()),
                 closingHours

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustom.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustom.java
@@ -6,7 +6,6 @@ import com.zelusik.eatery.constant.place.FilteringType;
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.dto.place.PlaceDto;
-import com.zelusik.eatery.dto.place.PlaceFilteringKeywordDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.lang.Nullable;
@@ -40,12 +39,4 @@ public interface PlaceRepositoryJCustom {
      * @return 조회된 장소 목록
      */
     Page<PlaceDto> findMarkedPlaces(Long memberId, FilteringType filteringType, String filteringKeyword, int numOfPlaceImages, Pageable pageable);
-
-    /**
-     * 북마크에 저장한 장소들에 대해 filtering keywords를 조회한다.
-     *
-     * @param memberId filtering keyword 목록을 조회하고자 하는 회원의 PK
-     * @return 조회된 filtering keywords
-     */
-    List<PlaceFilteringKeywordDto> getFilteringKeywords(Long memberId);
 }

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -401,7 +401,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
     }
 
     private RowMapper<PlaceFilteringKeywordDto> placeFilteringKeywordRowMapper(FilteringType filteringType) {
-        return (rs, rowNum) -> PlaceFilteringKeywordDto.of(
+        return (rs, rowNum) -> new PlaceFilteringKeywordDto(
                 rs.getString("keyword"),
                 rs.getInt("cnt"),
                 filteringType
@@ -446,7 +446,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
             if (count < minCount) {
                 continue;
             }
-            result.add(PlaceFilteringKeywordDto.of(keyword, count, FilteringType.ADDRESS));
+            result.add(new PlaceFilteringKeywordDto(keyword, count, FilteringType.ADDRESS));
         }
         return result;
     }
@@ -487,7 +487,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
             if (count < minCount) {
                 continue;
             }
-            result.add(PlaceFilteringKeywordDto.of(keyword, (int) count, FilteringType.TOP_3_KEYWORDS));
+            result.add(new PlaceFilteringKeywordDto(keyword, (int) count, FilteringType.TOP_3_KEYWORDS));
         }
         return result;
     }

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -322,7 +322,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
         filteringKeywords.addAll(getSecondCategoryFilteringKeywords(memberId, minCount));
         filteringKeywords.addAll(getAddressFilteringKeywords(memberId, minCount));
         filteringKeywords.addAll(getTop3KeywordFilteringKeywords(memberId, minCount));
-        filteringKeywords.sort(Comparator.comparing(PlaceFilteringKeywordDto::getCount));
+        filteringKeywords.sort(Comparator.comparing(PlaceFilteringKeywordDto::getCount).reversed());
 
         return filteringKeywords.size() < MAX_NUM_OF_FILTERING_KEYWORDS
                 ? filteringKeywords

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustom.java
@@ -1,13 +1,21 @@
 package com.zelusik.eatery.repository.place;
 
 import com.zelusik.eatery.domain.place.Place;
-import com.zelusik.eatery.dto.place.PlaceDto;
+import com.zelusik.eatery.dto.place.PlaceFilteringKeywordDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface PlaceRepositoryQCustom {
 
     Slice<Place> searchByKeyword(String keyword, Pageable pageable);
+
+    /**
+     * 북마크에 저장한 장소들에 대해 filtering keywords를 조회한다.
+     *
+     * @param loginMemberId PK of login member
+     * @return 조회된 filtering keywords
+     */
+    List<PlaceFilteringKeywordDto> getFilteringKeywords(long loginMemberId);
 }

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustom.java
@@ -9,7 +9,5 @@ import java.util.Optional;
 
 public interface PlaceRepositoryQCustom {
 
-    Optional<PlaceDto> findDtoWithMarkedStatus(Long id, Long memberId);
-
     Slice<Place> searchByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustomImpl.java
@@ -1,21 +1,27 @@
 package com.zelusik.eatery.repository.place;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zelusik.eatery.constant.place.FilteringType;
+import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.place.Place;
-import com.zelusik.eatery.dto.place.PlaceDto;
+import com.zelusik.eatery.dto.place.PlaceFilteringKeywordDto;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.util.StringUtils;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static com.zelusik.eatery.domain.QBookmark.bookmark;
 import static com.zelusik.eatery.domain.place.QPlace.place;
 
 @RequiredArgsConstructor
 public class PlaceRepositoryQCustomImpl implements PlaceRepositoryQCustom {
+
+    public static final int MAX_NUM_OF_FILTERING_KEYWORDS = 8;
 
     private final JPAQueryFactory queryFactory;
 
@@ -35,5 +41,168 @@ public class PlaceRepositoryQCustomImpl implements PlaceRepositoryQCustom {
         }
 
         return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public List<PlaceFilteringKeywordDto> getFilteringKeywords(long loginMemberId) {
+        Long numOfMarkedPlaces = queryFactory
+                .select(bookmark.count())
+                .from(bookmark)
+                .where(bookmark.member.id.eq(loginMemberId))
+                .fetchOne();
+        int minCount = numOfMarkedPlaces == null || numOfMarkedPlaces < 20 ? 3 : 5;
+
+        List<PlaceFilteringKeywordDto> result = new ArrayList<>();
+        result.addAll(getFilteringKeywordsForFirstCategory(loginMemberId, minCount));
+        result.addAll(getFilteringKeywordsForSecondCategory(loginMemberId, minCount));
+        result.addAll(getFilteringKeywordsForAddress(loginMemberId, minCount));
+        result.addAll(getFilteringKeywordsForTop3Keywords(loginMemberId, minCount));
+        result.sort(Comparator.comparing(PlaceFilteringKeywordDto::getCount).reversed());   // 개수 많은 순 정렬
+
+        return result.size() < MAX_NUM_OF_FILTERING_KEYWORDS ? result : result.subList(0, MAX_NUM_OF_FILTERING_KEYWORDS);
+    }
+
+    /**
+     * 저장된 장소들의 first category에 대한 filtering keywords를 조회한다.
+     *
+     * @param loginMemberId PK of login member
+     * @param minCount      filtering keyword가 되기 위한 최소 중복 개수. 3 또는 5
+     * @return 조회된 filtering keywords
+     */
+    @NonNull
+    private List<PlaceFilteringKeywordDto> getFilteringKeywordsForFirstCategory(long loginMemberId, int minCount) {
+        List<Tuple> tuples = queryFactory
+                .select(place.category.firstCategory,
+                        place.category.firstCategory.count().intValue())
+                .from(bookmark)
+                .join(bookmark.place, place)
+                .where(bookmark.member.id.eq(loginMemberId)
+                        .and(place.category.firstCategory.isNotEmpty()))
+                .groupBy(place.category.firstCategory)
+                .having(place.category.firstCategory.count().goe(minCount))
+                .fetch();
+
+        if (tuples == null || tuples.isEmpty()) {
+            return List.of();
+        }
+
+        return tuples.stream()
+                .map(tuple -> new PlaceFilteringKeywordDto(
+                        Objects.requireNonNull(tuple.get(place.category.firstCategory)),
+                        Objects.requireNonNull(tuple.get(place.category.firstCategory.count().intValue())),
+                        FilteringType.FIRST_CATEGORY
+                )).toList();
+    }
+
+    /**
+     * 저장된 장소들의 second category에 대한 filtering keywords를 조회한다.
+     *
+     * @param loginMemberId PK of login member
+     * @param minCount      filtering keyword가 되기 위한 최소 중복 개수. 3 또는 5
+     * @return 조회된 filtering keywords
+     */
+    @NonNull
+    private List<PlaceFilteringKeywordDto> getFilteringKeywordsForSecondCategory(long loginMemberId, int minCount) {
+        List<Tuple> tuples = queryFactory
+                .select(place.category.secondCategory,
+                        place.category.secondCategory.count().intValue())
+                .from(bookmark)
+                .join(bookmark.place, place)
+                .where(bookmark.member.id.eq(loginMemberId)
+                        .and(place.category.secondCategory.isNotEmpty()))
+                .groupBy(place.category.secondCategory)
+                .having(place.category.secondCategory.count().goe(minCount))
+                .fetch();
+
+        if (tuples == null || tuples.isEmpty()) {
+            return List.of();
+        }
+
+        return tuples.stream()
+                .map(tuple -> new PlaceFilteringKeywordDto(
+                        Objects.requireNonNull(tuple.get(place.category.secondCategory)),
+                        Objects.requireNonNull(tuple.get(place.category.secondCategory.count().intValue())),
+                        FilteringType.SECOND_CATEGORY
+                )).toList();
+    }
+
+    /**
+     * 저장된 장소들의 주소(읍면동 단위) 대한 filtering keywords를 조회한다.
+     *
+     * @param loginMemberId PK of login member
+     * @param minCount      filtering keyword가 되기 위한 최소 중복 개수. 3 또는 5
+     * @return 조회된 filtering keywords
+     */
+    @NonNull
+    private List<PlaceFilteringKeywordDto> getFilteringKeywordsForAddress(long loginMemberId, int minCount) {
+        List<String> lotNumberAddresses = queryFactory
+                .select(place.address.lotNumberAddress)
+                .from(bookmark)
+                .join(bookmark.place, place)
+                .where(bookmark.member.id.eq(loginMemberId)
+                        .and(place.address.lotNumberAddress.isNotNull()))
+                .fetch();
+
+        if (lotNumberAddresses == null || lotNumberAddresses.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> emdAddresses = lotNumberAddresses.stream()
+                .map(addr -> {
+                    if (!StringUtils.hasText(addr)) {
+                        return null;
+                    }
+                    return addr.substring(0, addr.indexOf(" "));
+                }).toList();
+
+        Map<String, Integer> countMap = new HashMap<>();
+        emdAddresses.forEach(emdAddr -> countMap.put(emdAddr, countMap.getOrDefault(emdAddr, 0) + 1));
+
+        List<PlaceFilteringKeywordDto> result = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : countMap.entrySet()) {
+            String keyword = entry.getKey();
+            int count = entry.getValue();
+            if (count < minCount) {
+                continue;
+            }
+            result.add(new PlaceFilteringKeywordDto(keyword, count, FilteringType.ADDRESS));
+        }
+        return result;
+    }
+
+    /**
+     * 저장된 장소들의 top 3 keywords 대한 filtering keywords를 조회한다.
+     *
+     * @param loginMemberId PK of login member
+     * @param minCount      filtering keyword가 되기 위한 최소 중복 개수. 3 또는 5
+     * @return 조회된 filtering keywords
+     */
+    @NonNull
+    private List<PlaceFilteringKeywordDto> getFilteringKeywordsForTop3Keywords(long loginMemberId, int minCount) {
+        List<List<ReviewKeywordValue>> top3KeywordsList = queryFactory
+                .select(place.top3Keywords)
+                .from(bookmark)
+                .join(bookmark.place, place)
+                .where(bookmark.member.id.eq(loginMemberId))
+                .fetch();
+
+        Map<ReviewKeywordValue, Integer> countMap = new HashMap<>();
+        top3KeywordsList.forEach(top3Keywords -> {
+            if (top3Keywords.isEmpty()) {
+                return;
+            }
+            top3Keywords.forEach(keyword -> countMap.put(keyword, countMap.getOrDefault(keyword, 0) + 1));
+        });
+
+        List<PlaceFilteringKeywordDto> result = new ArrayList<>();
+        for (Map.Entry<ReviewKeywordValue, Integer> entry : countMap.entrySet()) {
+            ReviewKeywordValue keyword = entry.getKey();
+            double count = (double) entry.getValue() / 2;   // top 3 keyword의 경우 다른 항목들에 비해 자주 겹치는 데이터이므로 실제 개수의 절반을 개수로 한다. (노션 기획 문서 참고)
+            if (count < minCount) {
+                continue;
+            }
+            result.add(new PlaceFilteringKeywordDto(keyword.getContent(), (int) count, FilteringType.TOP_3_KEYWORDS));
+        }
+        return result;
     }
 }

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryQCustomImpl.java
@@ -19,25 +19,6 @@ public class PlaceRepositoryQCustomImpl implements PlaceRepositoryQCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    public Optional<PlaceDto> findDtoWithMarkedStatus(Long id, Long memberId) {
-        Place result = queryFactory.selectFrom(place)
-                .where(place.id.eq(id))
-                .fetchOne();
-
-        if (result == null) {
-            return Optional.empty();
-        }
-
-        Long count = queryFactory.select(bookmark.count())
-                .from(bookmark)
-                .where(bookmark.place.id.eq(id)
-                        .and(bookmark.member.id.eq(memberId)))
-                .fetchOne();
-        boolean isMarked = count != null && count > 0;
-
-        return Optional.of(PlaceDto.from(result, isMarked));
-    }
-
     @Override
     public Slice<Place> searchByKeyword(String keyword, Pageable pageable) {
         List<Place> content = queryFactory

--- a/src/test/java/com/zelusik/eatery/domain/place/AddressTest.java
+++ b/src/test/java/com/zelusik/eatery/domain/place/AddressTest.java
@@ -27,7 +27,7 @@ class AddressTest {
         // given
 
         // when
-        Address address = new Address(fullLotNumberAddress, fullRoadAddress);
+        Address address = Address.of(fullLotNumberAddress, fullRoadAddress);
 
         // then
         assertThat(address.getSido()).isEqualTo(sido);

--- a/src/test/java/com/zelusik/eatery/integration/repository/place/PlaceRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/repository/place/PlaceRepositoryTest.java
@@ -31,7 +31,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static com.zelusik.eatery.constant.review.ReviewKeywordValue.*;
 import static com.zelusik.eatery.service.PlaceService.MAX_NUM_OF_PLACE_IMAGES;
@@ -149,6 +148,87 @@ class PlaceRepositoryTest {
         assertThat(content.get(2).getId()).isEqualTo(place4.getId());
     }
 
+    @DisplayName("내가 북마크한 장소들의 first category에 대한 filtering keywords를 개수가 많은 순으로 추출한다.")
+    @Test
+    void given_whenGetFilteringKeywordsForFirstCategoryOrderByCountDesc_thenReturnFilteringKeywords() {
+        // given
+        Member member = memberRepository.save(createNewMember("1"));
+        List<Place> places = sut.saveAll(List.of(
+                createNewPlace("1", new PlaceCategory("한식", "비빔밥", null)),
+                createNewPlace("2", new PlaceCategory("한식", "비빔밥", null)),
+                createNewPlace("3", new PlaceCategory("한식", "비빔밥", null)),
+                createNewPlace("4", new PlaceCategory("양식", "파스타", null)),
+                createNewPlace("5", new PlaceCategory("양식", "파스타", null)),
+                createNewPlace("6", new PlaceCategory("양식", "파스타", null)),
+                createNewPlace("7", new PlaceCategory("양식", "파스타", null)),
+                createNewPlace("8", new PlaceCategory("일식", "라멘", null)),
+                createNewPlace("9", new PlaceCategory("분식", null, null)),
+                createNewPlace("10", new PlaceCategory("", null, null)),
+                createNewPlace("11", new PlaceCategory("", null, null)),
+                createNewPlace("12", new PlaceCategory("", null, null))
+        ));
+        bookmarkRepository.saveAll(places.stream().map(place -> createNewBookmark(member, place)).toList());
+
+        // when
+        List<PlaceFilteringKeywordDto> filteringKeywords = sut.getFilteringKeywords(member.getId());
+
+        // then
+        List<PlaceFilteringKeywordDto> filteringKeywordsForSecondCategory = filteringKeywords.stream()
+                .filter(filteringKeyword -> filteringKeyword.getType().equals(FilteringType.FIRST_CATEGORY))
+                .toList();
+        assertThat(filteringKeywordsForSecondCategory).hasSize(2);
+        assertThat(filteringKeywordsForSecondCategory.get(0))
+                .hasFieldOrPropertyWithValue("keyword", "양식")
+                .hasFieldOrPropertyWithValue("count", 4)
+                .hasFieldOrPropertyWithValue("type", FilteringType.FIRST_CATEGORY);
+        assertThat(filteringKeywordsForSecondCategory.get(1))
+                .hasFieldOrPropertyWithValue("keyword", "한식")
+                .hasFieldOrPropertyWithValue("count", 3)
+                .hasFieldOrPropertyWithValue("type", FilteringType.FIRST_CATEGORY);
+    }
+
+    @DisplayName("내가 북마크한 장소들의 second category에 대한 filtering keywords를 개수가 많은 순으로 추출한다.")
+    @Test
+    void given_whenGetFilteringKeywordsForSecondCategoryOrderByCountDesc_thenReturnFilteringKeywords() {
+        // given
+        Member member = memberRepository.save(createNewMember("1"));
+        List<Place> places = sut.saveAll(List.of(
+                createNewPlace("1", new PlaceCategory("한식", "비빔밥", null)),
+                createNewPlace("2", new PlaceCategory("한식", "비빔밥", null)),
+                createNewPlace("3", new PlaceCategory("한식", "비빔밥", null)),
+                createNewPlace("4", new PlaceCategory("한식", "국밥", null)),
+                createNewPlace("5", new PlaceCategory("한식", "국밥", null)),
+                createNewPlace("6", new PlaceCategory("한식", "국밥", null)),
+                createNewPlace("7", new PlaceCategory("한식", "국밥", null)),
+                createNewPlace("8", new PlaceCategory("한식", "불고기", null)),
+                createNewPlace("9", new PlaceCategory("한식", "김밥", null)),
+                createNewPlace("10", new PlaceCategory("한식", "", null)),
+                createNewPlace("11", new PlaceCategory("한식", "", null)),
+                createNewPlace("12", new PlaceCategory("한식", "", null)),
+                createNewPlace("13", new PlaceCategory("한식", null, null)),
+                createNewPlace("14", new PlaceCategory("한식", null, null)),
+                createNewPlace("15", new PlaceCategory("한식", null, null))
+        ));
+        bookmarkRepository.saveAll(places.stream().map(place -> createNewBookmark(member, place)).toList());
+
+        // when
+        List<PlaceFilteringKeywordDto> filteringKeywords = sut.getFilteringKeywords(member.getId());
+
+        // then
+        List<PlaceFilteringKeywordDto> filteringKeywordsForSecondCategory = filteringKeywords.stream()
+                .filter(filteringKeyword -> filteringKeyword.getType().equals(FilteringType.SECOND_CATEGORY))
+                .toList();
+        assertThat(filteringKeywordsForSecondCategory).hasSize(2);
+        assertThat(filteringKeywordsForSecondCategory.get(0))
+                .hasFieldOrPropertyWithValue("keyword", "국밥")
+                .hasFieldOrPropertyWithValue("count", 4)
+                .hasFieldOrPropertyWithValue("type", FilteringType.SECOND_CATEGORY);
+        assertThat(filteringKeywordsForSecondCategory.get(1))
+                .hasFieldOrPropertyWithValue("keyword", "비빔밥")
+                .hasFieldOrPropertyWithValue("count", 3)
+                .hasFieldOrPropertyWithValue("type", FilteringType.SECOND_CATEGORY);
+    }
+
     @DisplayName("내가 북마크한 장소들의 top 3 keywords에 대한 filtering keywords를 개수가 많은 순으로 추출한다.")
     @Test
     void given_whenGetFilteringKeywordsForTop3KeywordsOrderByCountDesc_thenReturnFilteringKeywords() {
@@ -163,8 +243,9 @@ class PlaceRepositoryTest {
                 createNewPlace("6", List.of(FRESH, BEST_FLAVOR, WITH_ALCOHOL), "name"),
                 createNewPlace("7", List.of(FRESH, BEST_FLAVOR, WITH_ALCOHOL), "name"),
                 createNewPlace("8", List.of(FRESH, BEST_FLAVOR, NOISY), "name"),
-                createNewPlace("9", List.of(FRESH), "name"),
-                createNewPlace("10", List.of(), "name")
+                createNewPlace("9", List.of(FRESH, BEST_FLAVOR), "name"),
+                createNewPlace("10", List.of(FRESH), "name"),
+                createNewPlace("11", List.of(), "name")
         ));
         bookmarkRepository.saveAll(places.stream().map(place -> createNewBookmark(member, place)).toList());
 
@@ -177,15 +258,15 @@ class PlaceRepositoryTest {
                 .toList();
         assertThat(filteringKeywordsForTop3Keywords).hasSize(3);
         assertThat(filteringKeywordsForTop3Keywords.get(0))
-                .hasFieldOrPropertyWithValue("keyword", FRESH.name())
-                .hasFieldOrPropertyWithValue("count", 4)
+                .hasFieldOrPropertyWithValue("keyword", FRESH.getContent())
+                .hasFieldOrPropertyWithValue("count", 5)
                 .hasFieldOrPropertyWithValue("type", FilteringType.TOP_3_KEYWORDS);
         assertThat(filteringKeywordsForTop3Keywords.get(1))
-                .hasFieldOrPropertyWithValue("keyword", BEST_FLAVOR.name())
-                .hasFieldOrPropertyWithValue("count", 3)    // 3.5는 int type variable에 할당되면서 3으로 내림된다.
+                .hasFieldOrPropertyWithValue("keyword", BEST_FLAVOR.getContent())
+                .hasFieldOrPropertyWithValue("count", 4)    // 3.5는 int type variable에 할당되면서 3으로 내림된다.
                 .hasFieldOrPropertyWithValue("type", FilteringType.TOP_3_KEYWORDS);
         assertThat(filteringKeywordsForTop3Keywords.get(2))
-                .hasFieldOrPropertyWithValue("keyword", WITH_ALCOHOL.name())
+                .hasFieldOrPropertyWithValue("keyword", WITH_ALCOHOL.getContent())
                 .hasFieldOrPropertyWithValue("count", 3)
                 .hasFieldOrPropertyWithValue("type", FilteringType.TOP_3_KEYWORDS);
     }
@@ -225,15 +306,15 @@ class PlaceRepositoryTest {
                 .hasFieldOrPropertyWithValue("count", 3);
     }
 
-    private Member createNewMember(String socialId) {
+    private Member createNewMember(String socialUid) {
         return Member.of(
                 "https://default-profile-image",
                 "https://defualt-profile-thumbnail-image",
-                socialId,
+                socialUid,
                 LoginType.KAKAO,
                 Set.of(RoleType.USER),
-                "test" + socialId + "@test.com",
-                "test" + socialId,
+                "test" + socialUid + "@test.com",
+                "test" + socialUid,
                 null,
                 null
         );
@@ -245,6 +326,10 @@ class PlaceRepositoryTest {
 
     private Place createNewPlace(String kakaoPid, Address address) {
         return createNewPlace(kakaoPid, List.of(), "test", new PlaceCategory("한식", "냉면", null), address, null, "37", "127", null);
+    }
+
+    private Place createNewPlace(String kakaoPid, PlaceCategory category) {
+        return createNewPlace(kakaoPid, List.of(), "test", category, new Address("sido", "sigungu", "lot number address", "road address"), null, "37", "127", null);
     }
 
     private Place createNewPlace(String kakaoPid, List<ReviewKeywordValue> top3Keywords, String name) {

--- a/src/test/java/com/zelusik/eatery/integration/repository/recommended_review/RecommendedReviewRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/repository/recommended_review/RecommendedReviewRepositoryTest.java
@@ -146,7 +146,7 @@ class RecommendedReviewRepositoryTest {
                 KakaoCategoryGroupCode.FD6,
                 new PlaceCategory("한식", "냉면", null),
                 null,
-                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
                 "homepage url",
                 new Point("12.34", "23.45"),
                 null

--- a/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
@@ -213,8 +213,8 @@ class PlaceControllerTest {
         long memberId = 1L;
         given(placeService.getFilteringKeywords(memberId))
                 .willReturn(List.of(
-                        PlaceFilteringKeywordDto.of("연남동", 5, FilteringType.ADDRESS),
-                        PlaceFilteringKeywordDto.of("신선한 재료", 3, FilteringType.TOP_3_KEYWORDS)
+                        new PlaceFilteringKeywordDto("연남동", 5, FilteringType.ADDRESS),
+                        new PlaceFilteringKeywordDto("신선한 재료", 3, FilteringType.TOP_3_KEYWORDS)
                 ));
 
         // when & then

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -291,7 +291,7 @@ class ReviewControllerTest {
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
-                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
                 "https://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,

--- a/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
@@ -301,8 +301,8 @@ class PlaceServiceTest {
         long memberId = 1L;
         given(placeRepository.getFilteringKeywords(memberId))
                 .willReturn(List.of(
-                        PlaceFilteringKeywordDto.of("연남동", 5, FilteringType.ADDRESS),
-                        PlaceFilteringKeywordDto.of("신선한 재료", 3, FilteringType.TOP_3_KEYWORDS)
+                        new PlaceFilteringKeywordDto("연남동", 5, FilteringType.ADDRESS),
+                        new PlaceFilteringKeywordDto("신선한 재료", 3, FilteringType.TOP_3_KEYWORDS)
                 ));
 
         // when

--- a/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
@@ -360,7 +360,7 @@ class ReviewServiceTest {
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
-                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
                 "http://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,

--- a/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
@@ -41,7 +41,7 @@ public class PlaceTestUtils {
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
-                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
                 "http://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,
@@ -65,7 +65,7 @@ public class PlaceTestUtils {
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
-                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
                 "https://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,
@@ -97,7 +97,7 @@ public class PlaceTestUtils {
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
-                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
                 "https://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,
@@ -112,7 +112,7 @@ public class PlaceTestUtils {
     }
 
     public static Place createNewPlace(String kakaoPid, String name) {
-        return createNewPlace(kakaoPid, name, new PlaceCategory("한식", "냉면", null), new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"), "homepage-url", "12.34", "23.45", null);
+        return createNewPlace(kakaoPid, name, new PlaceCategory("한식", "냉면", null), Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"), "homepage-url", "12.34", "23.45", null);
     }
 
     public static Place createNewPlace(String kakaoPid, String name, PlaceCategory placeCategory, Address address) {
@@ -120,7 +120,7 @@ public class PlaceTestUtils {
     }
 
     public static Place createNewPlace(String kakaoPid, String name, String homepageUrl, String lat, String lng, String closingHours) {
-        return createNewPlace(kakaoPid, name, new PlaceCategory("한식", "냉면", null), new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"), homepageUrl, lat, lng, closingHours);
+        return createNewPlace(kakaoPid, name, new PlaceCategory("한식", "냉면", null), Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"), homepageUrl, lat, lng, closingHours);
     }
 
     public static Place createNewPlace(String kakaoPid, String name, PlaceCategory placeCategory, Address address, String homepageUrl, String lat, String lng, String closingHours) {
@@ -144,7 +144,7 @@ public class PlaceTestUtils {
     }
 
     public static Place createPlace(Long id, String kakaoPid, String name, PlaceCategory placeCategory, String homepageUrl, String lat, String lng, String closingHours) {
-        return createPlace(id, kakaoPid, name, placeCategory, new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"), homepageUrl, lat, lng, closingHours);
+        return createPlace(id, kakaoPid, name, placeCategory, Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"), homepageUrl, lat, lng, closingHours);
     }
 
     public static Place createPlace(Long id, String kakaoPid, String name, PlaceCategory placeCategory, Address address, String homepageUrl, String lat, String lng, String closingHours) {

--- a/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
@@ -8,7 +8,6 @@ import com.zelusik.eatery.dto.place.OpeningHoursDto;
 import com.zelusik.eatery.dto.place.PlaceDto;
 import com.zelusik.eatery.dto.place.PlaceMenusDto;
 import com.zelusik.eatery.dto.place.request.PlaceCreateRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -179,12 +178,6 @@ public class PlaceTestUtils {
                 openAt,
                 closeAt
         );
-    }
-
-    public static OpeningHours createOpeningHours(Long id, Place place, DayOfWeek dayOfWeek) {
-        OpeningHours openingHours = OpeningHours.of(place, dayOfWeek, LocalTime.now().minusHours(6), LocalTime.now());
-        ReflectionTestUtils.setField(openingHours, "id", id);
-        return openingHours;
     }
 
     public static PlaceMenusDto createPlaceMenusDto(Long id, Long placeId, List<String> menus) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #361

## 🏃‍ Task
- 필터링 조회 정렬 기준 수정 (개수 많은 순)
  - 원래 개수가 큰 순서대로 정렬되도록 구현해야 했는데, 현재 정렬 설정 코드가 그렇게 되어 있지 않아 수정함.
- Filtering keywords 조회 구현 기술 변경. `JdbcTemplate` => `Querydsl`

## 📄 Reference
- None
