### PR TITLE
API Versioning 적용

### DIFF
--- a/src/main/java/com/zelusik/eatery/config/SecurityConfig.java
+++ b/src/main/java/com/zelusik/eatery/config/SecurityConfig.java
@@ -40,18 +40,17 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITE_PATHS = {
-            "/api/auth/login/**",
-            "/api/auth/token",
-            "/api/auth/validity"
+            "/api/*/auth/login/**",
+            "/api/*/auth/token",
+            "/api/*/auth/validity"
     };
 
     private static final Map<String, HttpMethod> ADMIN_AUTH_LIST = Map.of(
-            "/api/places/*/menus", HttpMethod.DELETE
+            "/api/*/places/*/menus", HttpMethod.DELETE
     );
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        String[] rolesAboveManager = {RoleType.MANAGER.name(), RoleType.ADMIN.name()};
         String[] rolesAboveAdmin = {RoleType.ADMIN.name()};
 
         return http

--- a/src/main/java/com/zelusik/eatery/config/SecurityConfig.java
+++ b/src/main/java/com/zelusik/eatery/config/SecurityConfig.java
@@ -40,19 +40,18 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITE_PATHS = {
-            "/api/*/auth/login/**",
-            "/api/*/auth/token",
-            "/api/*/auth/validity"
+            "/api/v*/auth/login/**",
+            "/api/v*/auth/token",
+            "/api/v*/auth/validity"
     };
 
     private static final Map<String, HttpMethod> ADMIN_AUTH_LIST = Map.of(
-            "/api/*/places/*/menus", HttpMethod.DELETE
+            "/api/v*/places/*/menus", HttpMethod.DELETE
     );
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         String[] rolesAboveAdmin = {RoleType.ADMIN.name()};
-
         return http
                 .httpBasic().disable()
                 .csrf().disable()

--- a/src/main/java/com/zelusik/eatery/config/SwaggerConfig.java
+++ b/src/main/java/com/zelusik/eatery/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,26 +16,25 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI eateryApi(@Value("${eatery.app.version}") String appVersion) {
         return new OpenAPI()
-                .info(
-                        new Info()
-                                .title("Eatery API Docs")
-                                .description("CMC 12th 앱 프로젝트 Eatery의 API 명세서")
-                                .version(appVersion)
-                )
-                .externalDocs(
-                        new ExternalDocumentation()
-                                .description("Github organization of team zelusik")
-                                .url("https://github.com/Zelusik")
-                )
-                .components(
-                        new Components()
-                                .addSecuritySchemes(
-                                        "access-token",
-                                        new SecurityScheme()
-                                                .type(SecurityScheme.Type.HTTP)
-                                                .scheme("Bearer")
-                                                .bearerFormat("JWT")
-                                )
-                );
+                .info(new Info()
+                        .title("Eatery API Docs")
+                        .description("Eatery의 API 명세서")
+                        .version(appVersion))
+                .externalDocs(new ExternalDocumentation()
+                        .description("Github organization of team eatery")
+                        .url("https://github.com/Zelusik"))
+                .components(new Components().addSecuritySchemes(
+                        "access-token",
+                        new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("Bearer").bearerFormat("JWT")
+                ));
+    }
+
+    @Bean
+    public GroupedOpenApi groupedOpenApiVersion1() {
+        return GroupedOpenApi.builder()
+                .group("v1")
+                .packagesToScan("com.zelusik.eatery.controller")
+                .pathsToMatch("/api/v1/**")
+                .build();
     }
 }

--- a/src/main/java/com/zelusik/eatery/constant/ConstantUtil.java
+++ b/src/main/java/com/zelusik/eatery/constant/ConstantUtil.java
@@ -14,10 +14,7 @@ public class ConstantUtil {
     public static final String defaultProfileImageUrl = "https://eatery-s3-bucket.s3.ap-northeast-2.amazonaws.com/member/default-profile-image";
     public static final String defaultProfileThumbnailImageUrl = "https://eatery-s3-bucket.s3.ap-northeast-2.amazonaws.com/member/default-profile-image";
 
-    /**
-     * @see PlaceRepositoryJCustomImpl
-     */
-    public static final int MAX_NUM_OF_FILTERING_KEYWORDS = 8;
+    public static final String API_MINOR_VERSION_HEADER_NAME = "Eatery-API-Minor-Version";
 
     /**
      * @see MeetingPlaceController

--- a/src/main/java/com/zelusik/eatery/controller/AuthController.java
+++ b/src/main/java/com/zelusik/eatery/controller/AuthController.java
@@ -30,10 +30,10 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import java.util.Set;
 
-@Tag(name = "로그인 등 인증 관련")
+@Tag(name = "로그인 등 인증 관련 API")
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/api/auth")
+@RequestMapping("/api")
 @RestController
 public class AuthController {
 
@@ -54,8 +54,8 @@ public class AuthController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = LoginResponse.class))),
             @ApiResponse(description = "[10401] 유효하지 않은 kakao access token으로 요청한 경우.", responseCode = "401", content = @Content)
     })
-    @PostMapping("/login/kakao")
-    public LoginResponse kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
+    @PostMapping(value = "/v1/auth/login/kakao", headers = "Eatery-API-Minor-Version=1")
+    public LoginResponse kakaoLoginV1_1(@Valid @RequestBody KakaoLoginRequest request) {
         KakaoOAuthUserResponse userInfo = kakaoService.getUserInfo(request.getKakaoAccessToken());
 
         MemberDto memberDto = memberService.findOptionalDtoBySocialUidWithDeleted(userInfo.getSocialUid())
@@ -83,8 +83,8 @@ public class AuthController {
             @ApiResponse(description = "[1502] 유효하지 않은 token으로 요청한 경우. Token 값이 잘못되었거나 만료되어 유효하지 않은 경우로 token 갱신 필요", responseCode = "401", content = @Content),
             @ApiResponse(description = "[20000] Apple 로그인 과정에서 알 수 없는 에러가 발생한 경우. 서버 관리자에게 문의해주세요.", responseCode = "500", content = @Content)
     })
-    @PostMapping("/login/apple")
-    public LoginResponse appleLogin(@Valid @RequestBody AppleLoginRequest request) {
+    @PostMapping(value = "/v1/auth/login/apple", headers = "Eatery-API-Minor-Version=1")
+    public LoginResponse appleLoginV1_1(@Valid @RequestBody AppleLoginRequest request) {
         AppleOAuthUserResponse userInfo = appleOAuthService.getUserInfo(request.getIdentityToken());
 
         MemberDto memberDto = memberService.findOptionalDtoBySocialUidWithDeleted(userInfo.getSub())
@@ -107,8 +107,8 @@ public class AuthController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
             @ApiResponse(description = "[1504] 유효하지 않은 refresh token으로 요청한 경우. Token 값이 잘못되었거나 만료되어 유효하지 않은 경우로 token 갱신 필요", responseCode = "401", content = @Content),
     })
-    @PostMapping("/token")
-    public TokenResponse tokenRefresh(@Valid @RequestBody TokenRefreshRequest request) {
+    @PostMapping(value = "/v1/auth/token", headers = "Eatery-API-Minor-Version=1")
+    public TokenResponse tokenRefreshV1_1(@Valid @RequestBody TokenRefreshRequest request) {
         return jwtTokenService.refresh(request.getRefreshToken());
     }
 
@@ -122,8 +122,8 @@ public class AuthController {
                     "<li>Refresh token의 발행 기록을 찾을 수 없는 경우</li>" +
                     "</ul>"
     )
-    @GetMapping("/validity")
-    public TokenValidateResponse validate(@RequestParam @NotBlank String refreshToken) {
+    @GetMapping(value = "/v1/auth/validity", headers = "Eatery-API-Minor-Version=1")
+    public TokenValidateResponse validateRefreshTokenV1_1(@RequestParam @NotBlank String refreshToken) {
         return new TokenValidateResponse(jwtTokenService.validateOfRefreshToken(refreshToken));
     }
 }

--- a/src/main/java/com/zelusik/eatery/controller/AuthController.java
+++ b/src/main/java/com/zelusik/eatery/controller/AuthController.java
@@ -30,6 +30,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import java.util.Set;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
+
 @Tag(name = "로그인 등 인증 관련 API")
 @RequiredArgsConstructor
 @Validated
@@ -54,7 +56,7 @@ public class AuthController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = LoginResponse.class))),
             @ApiResponse(description = "[10401] 유효하지 않은 kakao access token으로 요청한 경우.", responseCode = "401", content = @Content)
     })
-    @PostMapping(value = "/v1/auth/login/kakao", headers = "Eatery-API-Minor-Version=1")
+    @PostMapping(value = "/v1/auth/login/kakao", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public LoginResponse kakaoLoginV1_1(@Valid @RequestBody KakaoLoginRequest request) {
         KakaoOAuthUserResponse userInfo = kakaoService.getUserInfo(request.getKakaoAccessToken());
 
@@ -83,7 +85,7 @@ public class AuthController {
             @ApiResponse(description = "[1502] 유효하지 않은 token으로 요청한 경우. Token 값이 잘못되었거나 만료되어 유효하지 않은 경우로 token 갱신 필요", responseCode = "401", content = @Content),
             @ApiResponse(description = "[20000] Apple 로그인 과정에서 알 수 없는 에러가 발생한 경우. 서버 관리자에게 문의해주세요.", responseCode = "500", content = @Content)
     })
-    @PostMapping(value = "/v1/auth/login/apple", headers = "Eatery-API-Minor-Version=1")
+    @PostMapping(value = "/v1/auth/login/apple", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public LoginResponse appleLoginV1_1(@Valid @RequestBody AppleLoginRequest request) {
         AppleOAuthUserResponse userInfo = appleOAuthService.getUserInfo(request.getIdentityToken());
 
@@ -107,7 +109,7 @@ public class AuthController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
             @ApiResponse(description = "[1504] 유효하지 않은 refresh token으로 요청한 경우. Token 값이 잘못되었거나 만료되어 유효하지 않은 경우로 token 갱신 필요", responseCode = "401", content = @Content),
     })
-    @PostMapping(value = "/v1/auth/token", headers = "Eatery-API-Minor-Version=1")
+    @PostMapping(value = "/v1/auth/token", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public TokenResponse tokenRefreshV1_1(@Valid @RequestBody TokenRefreshRequest request) {
         return jwtTokenService.refresh(request.getRefreshToken());
     }
@@ -122,7 +124,7 @@ public class AuthController {
                     "<li>Refresh token의 발행 기록을 찾을 수 없는 경우</li>" +
                     "</ul>"
     )
-    @GetMapping(value = "/v1/auth/validity", headers = "Eatery-API-Minor-Version=1")
+    @GetMapping(value = "/v1/auth/validity", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public TokenValidateResponse validateRefreshTokenV1_1(@RequestParam @NotBlank String refreshToken) {
         return new TokenValidateResponse(jwtTokenService.validateOfRefreshToken(refreshToken));
     }

--- a/src/main/java/com/zelusik/eatery/controller/BookmarkController.java
+++ b/src/main/java/com/zelusik/eatery/controller/BookmarkController.java
@@ -20,7 +20,7 @@ import java.net.URI;
 
 @Tag(name = "북마크 API")
 @RequiredArgsConstructor
-@RequestMapping("/api/bookmarks")
+@RequestMapping("/api")
 @RestController
 public class BookmarkController {
 
@@ -35,8 +35,8 @@ public class BookmarkController {
             @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = BookmarkResponse.class))),
             @ApiResponse(description = "[4300] 이미 저장한 장소를 다시 북마크에 저장하고자 하는 경우", responseCode = "409", content = @Content)
     })
-    @PostMapping
-    public ResponseEntity<BookmarkResponse> mark(
+    @PostMapping(value = "/v1/bookmarks", headers = "Eatery-API-Minor-Version=1")
+    public ResponseEntity<BookmarkResponse> markPlaceV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "북마크에 저장하고자 하는 장소의 PK",
@@ -46,7 +46,7 @@ public class BookmarkController {
         BookmarkResponse response = BookmarkResponse.from(bookmarkService.mark(userPrincipal.getMemberId(), placeId));
 
         return ResponseEntity
-                .created(URI.create("/api/bookmarks/" + response.getId()))
+                .created(URI.create("/api/v1/bookmarks/" + response.getId()))
                 .body(response);
     }
 
@@ -59,8 +59,8 @@ public class BookmarkController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content),
             @ApiResponse(description = "[4301] 북마크에 저장하지 않은 장소인 경우.", responseCode = "404", content = @Content)
     })
-    @DeleteMapping
-    public void delete(
+    @DeleteMapping(value = "/v1/bookmarks", headers = "Eatery-API-Minor-Version=1")
+    public void deletePlaceBookmarkV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "저장된 북마크를 삭제하고자 하는 장소의 PK",

--- a/src/main/java/com/zelusik/eatery/controller/BookmarkController.java
+++ b/src/main/java/com/zelusik/eatery/controller/BookmarkController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
+
 @Tag(name = "북마크 API")
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -35,7 +37,7 @@ public class BookmarkController {
             @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = BookmarkResponse.class))),
             @ApiResponse(description = "[4300] 이미 저장한 장소를 다시 북마크에 저장하고자 하는 경우", responseCode = "409", content = @Content)
     })
-    @PostMapping(value = "/v1/bookmarks", headers = "Eatery-API-Minor-Version=1")
+    @PostMapping(value = "/v1/bookmarks", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public ResponseEntity<BookmarkResponse> markPlaceV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
@@ -59,7 +61,7 @@ public class BookmarkController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content),
             @ApiResponse(description = "[4301] 북마크에 저장하지 않은 장소인 경우.", responseCode = "404", content = @Content)
     })
-    @DeleteMapping(value = "/v1/bookmarks", headers = "Eatery-API-Minor-Version=1")
+    @DeleteMapping(value = "/v1/bookmarks", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public void deletePlaceBookmarkV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(

--- a/src/main/java/com/zelusik/eatery/controller/MeetingPlaceController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MeetingPlaceController.java
@@ -28,7 +28,7 @@ import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_ME
 @Tag(name = "약속 장소 관련 API")
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/api/meeting-places")
+@RequestMapping("/api")
 @RestController
 public class MeetingPlaceController {
 
@@ -42,8 +42,8 @@ public class MeetingPlaceController {
                     "<p>한 페이지에 제공되는 장소의 개수는 30개 미만입니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping
-    public SliceResponse<MeetingPlaceResponse> searchMeetingPlaces(
+    @GetMapping(value = "/v1/meeting-places", headers = "Eatery-API-Minor-Version=1")
+    public SliceResponse<MeetingPlaceResponse> searchMeetingPlacesV1_1(
             @Parameter(
                     description = "검색 키워드",
                     example = "광교"

--- a/src/main/java/com/zelusik/eatery/controller/MeetingPlaceController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MeetingPlaceController.java
@@ -23,6 +23,7 @@ import javax.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
 
 @Tag(name = "약속 장소 관련 API")
@@ -42,7 +43,7 @@ public class MeetingPlaceController {
                     "<p>한 페이지에 제공되는 장소의 개수는 30개 미만입니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping(value = "/v1/meeting-places", headers = "Eatery-API-Minor-Version=1")
+    @GetMapping(value = "/v1/meeting-places", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public SliceResponse<MeetingPlaceResponse> searchMeetingPlacesV1_1(
             @Parameter(
                     description = "검색 키워드",

--- a/src/main/java/com/zelusik/eatery/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MemberController.java
@@ -26,6 +26,8 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
+
 @Tag(name = "회원 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -39,7 +41,7 @@ public class MemberController {
             description = "내 정보를 조회합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping(value = "/v1/members/me", headers = "Eatery-API-Minor-Version=1")
+    @GetMapping(value = "/v1/members/me", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public GetMyInfoResponse getMyInfoV1_1(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         return GetMyInfoResponse.from(memberService.findDtoById(userPrincipal.getMemberId()));
     }
@@ -62,7 +64,7 @@ public class MemberController {
                     """,
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping(value = "/v1/members/me/profile", headers = "Eatery-API-Minor-Version=1")
+    @GetMapping(value = "/v1/members/me/profile", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public GetMyProfileInfoResponse getMyProfileInfoV1_1(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         return GetMyProfileInfoResponse.from(memberService.getMemberProfileInfoById(userPrincipal.getMemberId()));
     }
@@ -89,7 +91,7 @@ public class MemberController {
             @ApiResponse(description = "OK", responseCode = "200"),
             @ApiResponse(description = "[2000] 전달받은 <code>memberId</code>에 해당하는 회원을 찾을 수 없는 경우", responseCode = "404", content = @Content)
     })
-    @GetMapping(value = "/v1/members/{memberId}/profile", headers = "Eatery-API-Minor-Version=1")
+    @GetMapping(value = "/v1/members/{memberId}/profile", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public GetMemberProfileInfoResponse getMemberProfileInfoV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long memberId
@@ -103,7 +105,7 @@ public class MemberController {
             description = "검색 키워드를 전달받아 회원을 검색한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping(value = "/v1/members/search", headers = "Eatery-API-Minor-Version=1")
+    @GetMapping(value = "/v1/members/search", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public SliceResponse<SearchMembersByKeywordResponse> searchMembersByKeywordV1_1(
             @Parameter(
                     description = "검색 키워드",
@@ -129,7 +131,7 @@ public class MemberController {
                           "수정하지 않는 경우 보내지 않거나 <code>null</code>로 보내야 한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PutMapping(value = "/v1/members", headers = "Eatery-API-Minor-Version=1", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping(value = "/v1/members", headers = API_MINOR_VERSION_HEADER_NAME + "=1", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public MemberResponse updateMemberV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @ModelAttribute MemberUpdateRequest memberUpdateRequest
@@ -143,7 +145,7 @@ public class MemberController {
             description = "<p>선호하는 음식 카테고리(음식 취향)를 변경한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PutMapping(value = "/v1/members/favorite-food", headers = "Eatery-API-Minor-Version=1")
+    @PutMapping(value = "/v1/members/favorite-food", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public UpdateFavoriteFoodCategoriesResponse updateFavoriteFoodCategoriesV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody FavoriteFoodCategoriesUpdateRequest request
@@ -157,7 +159,7 @@ public class MemberController {
             description = "<p>회원 탈퇴를 진행한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @DeleteMapping(value = "/v1/members", headers = "Eatery-API-Minor-Version=1")
+    @DeleteMapping(value = "/v1/members", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public MemberDeletionSurveyResponse deleteV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody MemberDeletionSurveyRequest memberDeletionSurveyRequest

--- a/src/main/java/com/zelusik/eatery/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MemberController.java
@@ -28,7 +28,7 @@ import javax.validation.constraints.NotEmpty;
 
 @Tag(name = "회원 관련 API")
 @RequiredArgsConstructor
-@RequestMapping("/api/members")
+@RequestMapping("/api")
 @RestController
 public class MemberController {
 
@@ -39,8 +39,8 @@ public class MemberController {
             description = "내 정보를 조회합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/me")
-    public GetMyInfoResponse getMyInfo(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+    @GetMapping(value = "/v1/members/me", headers = "Eatery-API-Minor-Version=1")
+    public GetMyInfoResponse getMyInfoV1_1(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         return GetMyInfoResponse.from(memberService.findDtoById(userPrincipal.getMemberId()));
     }
 
@@ -62,8 +62,8 @@ public class MemberController {
                     """,
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/me/profile")
-    public GetMyProfileInfoResponse getMyProfileInfo(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+    @GetMapping(value = "/v1/members/me/profile", headers = "Eatery-API-Minor-Version=1")
+    public GetMyProfileInfoResponse getMyProfileInfoV1_1(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         return GetMyProfileInfoResponse.from(memberService.getMemberProfileInfoById(userPrincipal.getMemberId()));
     }
 
@@ -89,8 +89,8 @@ public class MemberController {
             @ApiResponse(description = "OK", responseCode = "200"),
             @ApiResponse(description = "[2000] 전달받은 <code>memberId</code>에 해당하는 회원을 찾을 수 없는 경우", responseCode = "404", content = @Content)
     })
-    @GetMapping("/{memberId}/profile")
-    public GetMemberProfileInfoResponse getMemberProfileInfo(
+    @GetMapping(value = "/v1/members/{memberId}/profile", headers = "Eatery-API-Minor-Version=1")
+    public GetMemberProfileInfoResponse getMemberProfileInfoV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long memberId
     ) {
@@ -103,8 +103,8 @@ public class MemberController {
             description = "검색 키워드를 전달받아 회원을 검색한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/search")
-    public SliceResponse<SearchMembersByKeywordResponse> searchMembersByKeyword(
+    @GetMapping(value = "/v1/members/search", headers = "Eatery-API-Minor-Version=1")
+    public SliceResponse<SearchMembersByKeywordResponse> searchMembersByKeywordV1_1(
             @Parameter(
                     description = "검색 키워드",
                     example = "강남"
@@ -129,8 +129,8 @@ public class MemberController {
                           "수정하지 않는 경우 보내지 않거나 <code>null</code>로 보내야 한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public MemberResponse updateMember(
+    @PutMapping(value = "/v1/members", headers = "Eatery-API-Minor-Version=1", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public MemberResponse updateMemberV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @ModelAttribute MemberUpdateRequest memberUpdateRequest
     ) {
@@ -143,8 +143,8 @@ public class MemberController {
             description = "<p>선호하는 음식 카테고리(음식 취향)를 변경한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PutMapping("/favorite-food")
-    public UpdateFavoriteFoodCategoriesResponse updateFavoriteFoodCategories(
+    @PutMapping(value = "/v1/members/favorite-food", headers = "Eatery-API-Minor-Version=1")
+    public UpdateFavoriteFoodCategoriesResponse updateFavoriteFoodCategoriesV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody FavoriteFoodCategoriesUpdateRequest request
     ) {
@@ -157,8 +157,8 @@ public class MemberController {
             description = "<p>회원 탈퇴를 진행한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @DeleteMapping
-    public MemberDeletionSurveyResponse delete(
+    @DeleteMapping(value = "/v1/members", headers = "Eatery-API-Minor-Version=1")
+    public MemberDeletionSurveyResponse deleteV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody MemberDeletionSurveyRequest memberDeletionSurveyRequest
     ) {

--- a/src/main/java/com/zelusik/eatery/controller/MenuKeywordController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MenuKeywordController.java
@@ -25,7 +25,7 @@ import static com.zelusik.eatery.constant.MenuKeywordCategory.MENU_NAME;
 import static com.zelusik.eatery.constant.MenuKeywordCategory.PLACE_CATEGORY;
 
 @Tag(name = "메뉴 키워드(맛, 평가, 느낌 등) 관련 API")
-@RequestMapping("/api/menu-keywords")
+@RequestMapping("/api")
 @Validated
 @RequiredArgsConstructor
 @RestController
@@ -38,8 +38,8 @@ public class MenuKeywordController {
             description = "각 메뉴에 대해 적절한 키워드 목록을 조회합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping
-    public MenuKeywordListResponseList getMenuKeywords(
+    @GetMapping(value = "/v1/menu-keywords", headers = "Eatery-API-Minor-Version=1")
+    public MenuKeywordListResponseList getMenuKeywordsV1_1(
             @Parameter(
                     description = "<p>리뷰를 작성하고자 하는 장소의 카테고리 정보. Kakao에서 전달받은 정보 그대로 사용한다.",
                     example = "음식점 > 한식 > 육류,고기 > 삼겹살"

--- a/src/main/java/com/zelusik/eatery/controller/MenuKeywordController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MenuKeywordController.java
@@ -21,6 +21,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.constant.MenuKeywordCategory.MENU_NAME;
 import static com.zelusik.eatery.constant.MenuKeywordCategory.PLACE_CATEGORY;
 
@@ -38,7 +39,7 @@ public class MenuKeywordController {
             description = "각 메뉴에 대해 적절한 키워드 목록을 조회합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping(value = "/v1/menu-keywords", headers = "Eatery-API-Minor-Version=1")
+    @GetMapping(value = "/v1/menu-keywords", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public MenuKeywordListResponseList getMenuKeywordsV1_1(
             @Parameter(
                     description = "<p>리뷰를 작성하고자 하는 장소의 카테고리 정보. Kakao에서 전달받은 정보 그대로 사용한다.",

--- a/src/main/java/com/zelusik/eatery/controller/PlaceController.java
+++ b/src/main/java/com/zelusik/eatery/controller/PlaceController.java
@@ -37,10 +37,12 @@ import javax.validation.constraints.NotEmpty;
 import java.net.URI;
 import java.util.List;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
+
 @Tag(name = "장소 관련 API")
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/api/places")
+@RequestMapping("/api")
 @RestController
 public class PlaceController {
 
@@ -56,15 +58,15 @@ public class PlaceController {
             @ApiResponse(description = "[3000] 동일한 장소 데이터가 이미 존재하는 경우", responseCode = "409", content = @Content),
             @ApiResponse(description = "[1350] 장소에 대한 추가 정보를 추출할 Scraping server에서 에러가 발생한 경우.", responseCode = "500", content = @Content)
     })
-    @PostMapping
-    public ResponseEntity<PlaceResponse> save(
+    @PostMapping(value = "/v1/places", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public ResponseEntity<PlaceResponse> saveV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody PlaceCreateRequest request
     ) {
         PlaceResponse response = PlaceResponse.from(placeService.create(userPrincipal.getMemberId(), request));
 
         return ResponseEntity
-                .created(URI.create("/api/places/" + response.getId()))
+                .created(URI.create("/api/v1/places/" + response.getId()))
                 .body(response);
     }
 
@@ -77,8 +79,8 @@ public class PlaceController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = PlaceResponse.class))),
             @ApiResponse(description = "[3001] 찾고자 하는 장소가 존재하지 않는 경우", responseCode = "404", content = @Content)
     })
-    @GetMapping("/{placeId}")
-    public FindPlaceResponse findPlaceById(
+    @GetMapping(value = "/v1/places/{placeId}", headers = API_MINOR_VERSION_HEADER_NAME)
+    public FindPlaceResponse findPlaceByIdV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "PK of place",
@@ -98,8 +100,8 @@ public class PlaceController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = PlaceResponse.class))),
             @ApiResponse(description = "[3001] 찾고자 하는 장소가 존재하지 않는 경우", responseCode = "404", content = @Content)
     })
-    @GetMapping
-    public FindPlaceResponse findPlaceByKakaoPid(
+    @GetMapping(value = "/v1/places", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public FindPlaceResponse findPlaceByKakaoPidV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "Kakao place unique id",
@@ -115,8 +117,8 @@ public class PlaceController {
             description = "키워드로 장소를 검색한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/search")
-    public SliceResponse<SearchPlacesByKeywordResponse> searchPlacesByKeyword(
+    @GetMapping(value = "/v1/places/search", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public SliceResponse<SearchPlacesByKeywordResponse> searchPlacesByKeywordV1_1(
             @Parameter(
                     description = "검색 키워드",
                     example = "강남"
@@ -139,12 +141,12 @@ public class PlaceController {
             description = "중심 좌표를 받아 중심 좌표에서 가까운 장소들을 검색합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/near")
+    @GetMapping(value = "/v1/places/near", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     @ApiResponses({
             @ApiResponse(description = "OK", responseCode = "200"),
             @ApiResponse(description = "[3505] <code>preferredVibe</code>에 분위기에 대한 내용이 아닌 값이 주어진 경우", responseCode = "400", content = @Content)
     })
-    public PageResponse<FindNearPlacesResponse> findNearPlaces(
+    public PageResponse<FindNearPlacesResponse> findNearPlacesV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "중심 위치 - 위도",
@@ -202,8 +204,8 @@ public class PlaceController {
                           "<p>필터링 키워드에 대한 설명은 <strong><a href=\"https://www.notion.so/asdfqweasd/f6f39969ea1e48f8afee61e696e4d038?pvs=4\">[노션]데이터</a> - MY 저장 페이지: 상단버튼</strong>을 참고해주세요.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/bookmarks/filtering-keywords")
-    public PlaceFilteringKeywordListResponse getFilteringKeywords(
+    @GetMapping(value = "/v1/places/bookmarks/filtering-keywords", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public PlaceFilteringKeywordListResponse getFilteringKeywordsV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
         List<PlaceFilteringKeywordResponse> filteringKeywords = placeService.getFilteringKeywords(userPrincipal.getMemberId()).stream()
@@ -218,8 +220,8 @@ public class PlaceController {
                           "<p>정렬 기준은 최근에 북마크에 저장한 순서입니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/bookmarks")
-    public PageResponse<FindMarkedPlacesResponse> findMarkedPlaces(
+    @GetMapping(value = "/v1/places/bookmarks", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public PageResponse<FindMarkedPlacesResponse> findMarkedPlacesV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "<p>Filtering 조건 유형. 값은 다음과 같습니다." +

--- a/src/main/java/com/zelusik/eatery/controller/PlaceMenusController.java
+++ b/src/main/java/com/zelusik/eatery/controller/PlaceMenusController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.net.URI;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
+
 @Tag(name = "장소 메뉴 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -38,11 +40,11 @@ public class PlaceMenusController {
             @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = PlaceMenusResponse.class))),
             @ApiResponse(description = "[3005] 메뉴 목록 데이터가 이미 존재하는 경우.", responseCode = "409", content = @Content)
     })
-    @PostMapping("/places/{placeId}/menus")
-    public ResponseEntity<PlaceMenusResponse> savePlaceMenusByPlaceId(@Parameter(description = "PK of place", example = "3") @PathVariable Long placeId) {
+    @PostMapping(value = "/v1/places/{placeId}/menus", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public ResponseEntity<PlaceMenusResponse> savePlaceMenusByPlaceIdV1_1(@Parameter(description = "PK of place", example = "3") @PathVariable Long placeId) {
         PlaceMenusDto result = placeMenusService.savePlaceMenus(placeId);
         return ResponseEntity
-                .created(URI.create("/api/places/" + placeId + "/menus"))
+                .created(URI.create("/api/v1/places/" + placeId + "/menus"))
                 .body(PlaceMenusResponse.from(result));
     }
 
@@ -56,11 +58,11 @@ public class PlaceMenusController {
             @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = PlaceMenusResponse.class))),
             @ApiResponse(description = "[3005] 메뉴 목록 데이터가 이미 존재하는 경우.", responseCode = "409", content = @Content)
     })
-    @PostMapping("/places/menus")
-    public ResponseEntity<PlaceMenusResponse> savePlaceMenusByKakaoPid(@Parameter(description = "장소의 고유 id", example = "1879186093") @RequestParam String kakaoPid) {
+    @PostMapping(value = "/v1/places/menus", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public ResponseEntity<PlaceMenusResponse> savePlaceMenusByKakaoPidV1_1(@Parameter(description = "장소의 고유 id", example = "1879186093") @RequestParam String kakaoPid) {
         PlaceMenusDto result = placeMenusService.savePlaceMenus(kakaoPid);
         return ResponseEntity
-                .created(URI.create("/api/places/" + result.getPlaceId() + "/menus"))
+                .created(URI.create("/api/v1/places/" + result.getPlaceId() + "/menus"))
                 .body(PlaceMenusResponse.from(result));
     }
 
@@ -73,8 +75,8 @@ public class PlaceMenusController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = PlaceMenusResponse.class))),
             @ApiResponse(description = "[3004] 일치하는 장소의 메뉴 데이터를 찾을 수 없는 경우.", responseCode = "404", content = @Content)
     })
-    @GetMapping("/places/{placeId}/menus")
-    public PlaceMenusResponse findPlaceMenusByPlaceId(@Parameter(description = "PK of place", example = "3") @PathVariable Long placeId) {
+    @GetMapping(value = "/v1/places/{placeId}/menus",headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public PlaceMenusResponse findPlaceMenusByPlaceIdV1_1(@Parameter(description = "PK of place", example = "3") @PathVariable Long placeId) {
         PlaceMenusDto result = placeMenusService.findDtoByPlaceId(placeId);
         return PlaceMenusResponse.fromWithoutIds(result);
     }
@@ -84,8 +86,8 @@ public class PlaceMenusController {
             description = "<p><code>kakaoPid</code>에 해당하는 장소의 메뉴 목록 데이터를 조회한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/places/menus")
-    public PlaceMenusResponse findPlaceMenusByKakaoPid(@Parameter(description = "장소의 고유 id", example = "1879186093") @RequestParam String kakaoPid) {
+    @GetMapping(value = "/v1/places/menus", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public PlaceMenusResponse findPlaceMenusByKakaoPidV1_1(@Parameter(description = "장소의 고유 id", example = "1879186093") @RequestParam String kakaoPid) {
         PlaceMenusDto result = placeMenusService.findDtoByKakaoPid(kakaoPid);
         return PlaceMenusResponse.fromWithoutIds(result);
     }
@@ -100,8 +102,8 @@ public class PlaceMenusController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = PlaceMenusResponse.class))),
             @ApiResponse(description = "[3006] 전달받은 메뉴 목록에 중복된 메뉴가 존재하는 경우", responseCode = "400", content = @Content)
     })
-    @PutMapping("/places/{placeId}/menus")
-    public PlaceMenusResponse updatePlaceMenus(
+    @PutMapping(value = "/v1/places/{placeId}/menus", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public PlaceMenusResponse updatePlaceMenusV1_1(
             @Parameter(description = "PK of place", example = "3") @PathVariable Long placeId,
             @RequestBody PlaceMenusUpdateRequest request
     ) {
@@ -118,8 +120,8 @@ public class PlaceMenusController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = PlaceMenusResponse.class))),
             @ApiResponse(description = "[3006] 전달받은 메뉴가 기존 메뉴 목록에 이미 존재하는 경우. 즉, 중복된 경우이므로 다른 값으로 요청해야 한다.", responseCode = "400", content = @Content)
     })
-    @PatchMapping("/places/{placeId}/menus")
-    public PlaceMenusResponse addMenuToPlaceMenus(
+    @PatchMapping(value = "/v1/places/{placeId}/menus", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public PlaceMenusResponse addMenuToPlaceMenusV1_1(
             @Parameter(description = "PK of place", example = "3") @PathVariable Long placeId,
             @Valid @RequestBody AddMenuToPlaceMenusRequest request
     ) {
@@ -133,8 +135,8 @@ public class PlaceMenusController {
                     "<p>관리자 권한을 가진 사용자만 사용 가능하다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @DeleteMapping("/places/{placeId}/menus")
-    public void deletePlaceMenus(@Parameter(description = "PK of place", example = "3") @PathVariable Long placeId) {
+    @DeleteMapping(value = "/v1/places/{placeId}/menus",headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public void deletePlaceMenusV1_1(@Parameter(description = "PK of place", example = "3") @PathVariable Long placeId) {
         placeMenusService.delete(placeId);
     }
 }

--- a/src/main/java/com/zelusik/eatery/controller/RecommendedReviewController.java
+++ b/src/main/java/com/zelusik/eatery/controller/RecommendedReviewController.java
@@ -21,6 +21,8 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
+
 @Tag(name = "추천 리뷰 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -34,14 +36,14 @@ public class RecommendedReviewController {
             description = "내 추천 리뷰를 지정하여 저장합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PostMapping("/members/recommended-reviews")
-    public ResponseEntity<SaveRecommendedReviewsResponse> saveRecommendedReviews(
+    @PostMapping(value = "/v1/members/recommended-reviews", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public ResponseEntity<SaveRecommendedReviewsResponse> saveRecommendedReviewsV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestBody @Valid SaveRecommendedReviewsRequest saveRecommendedReviewsRequest
     ) {
         RecommendedReviewDto recommendedReviewDto = recommendedReviewService.saveRecommendedReview(userPrincipal.getMemberId(), saveRecommendedReviewsRequest.getReviewId(), saveRecommendedReviewsRequest.getRanking());
         return ResponseEntity
-                .created(URI.create("/api/members/recommended-reviews/" + recommendedReviewDto.getId()))
+                .created(URI.create("/api/v1/members/recommended-reviews/" + recommendedReviewDto.getId()))
                 .body(SaveRecommendedReviewsResponse.from(recommendedReviewDto));
     }
 
@@ -50,8 +52,8 @@ public class RecommendedReviewController {
             description = "전달받은 <code>memberId</code>에 해당하는 회원의 추천 리뷰 정보를 조회합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/members/{memberId}/recommended-reviews")
-    public FindRecommendedReviewsResponse findRecommendedReviews(@PathVariable Long memberId) {
+    @GetMapping(value = "/v1/members/{memberId}/recommended-reviews", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public FindRecommendedReviewsResponse findRecommendedReviewsV1_1(@PathVariable Long memberId) {
         List<RecommendedReviewDto> recommendedReviews = recommendedReviewService.findAllDtosWithPlaceMarkedStatus(memberId);
         return FindRecommendedReviewsResponse.from(recommendedReviews);
     }
@@ -61,8 +63,8 @@ public class RecommendedReviewController {
             description = "로그인 회원의 추천 리뷰 정보를 조회합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/members/me/recommended-reviews")
-    public FindMyRecommendedReviewsResponse findMyRecommendedReviews(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+    @GetMapping(value = "/v1/members/me/recommended-reviews", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public FindMyRecommendedReviewsResponse findMyRecommendedReviewsV1_1(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         List<RecommendedReviewDto> recommendedReviews = recommendedReviewService.findAllDtosWithPlaceMarkedStatus(userPrincipal.getMemberId());
         return FindMyRecommendedReviewsResponse.from(recommendedReviews);
     }
@@ -73,8 +75,8 @@ public class RecommendedReviewController {
                           "<p>기존 등록된 추천 리뷰 내역을 전부 삭제한 후, 새로 전달받은 추천 리뷰 목록으로 대체한다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @PutMapping("/members/recommended-reviews/batch-update")
-    public BatchUpdateRecommendedReviewsResponse batchUpdateRecommendedReviews(
+    @PutMapping(value = "/v1/members/recommended-reviews/batch-update", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public BatchUpdateRecommendedReviewsResponse batchUpdateRecommendedReviewsV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestBody @Valid BatchUpdateRecommendedReviewsRequest saveRecommendedReviewsRequest
     ) {

--- a/src/main/java/com/zelusik/eatery/controller/ReviewController.java
+++ b/src/main/java/com/zelusik/eatery/controller/ReviewController.java
@@ -36,12 +36,13 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.constant.review.ReviewEmbedOption.PLACE;
 
 @Tag(name = "리뷰 관련 API")
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/api/reviews")
+@RequestMapping("/api")
 @RestController
 public class ReviewController {
 
@@ -60,8 +61,8 @@ public class ReviewController {
             @ApiResponse(description = "[1001] 전달받은 파일을 읽을 수 없는 경우.", responseCode = "400", content = @Content),
             @ApiResponse(description = "[1350] 장소에 대한 추가 정보를 스크래핑 할 Scraping server에서 에러가 발생한 경우.", responseCode = "500", content = @Content),
     })
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ReviewResponse> create(
+    @PostMapping(value = "/v1/reviews", headers = API_MINOR_VERSION_HEADER_NAME + "=1",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ReviewResponse> createV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @ParameterObject @Valid @ModelAttribute ReviewCreateRequest request
     ) {
@@ -80,8 +81,8 @@ public class ReviewController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = FindReviewResponse.class))),
             @ApiResponse(description = "[3501] <code>reviewId</code>에 해당하는 리뷰를 찾을 수 없는 경우", responseCode = "404", content = @Content)
     })
-    @GetMapping("/{reviewId}")
-    public FindReviewResponse findReview(
+    @GetMapping(value = "/v1/reviews/{reviewId}", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public FindReviewResponse findReviewV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "PK of review",
@@ -98,8 +99,8 @@ public class ReviewController {
             description = "리뷰 목록을 조회합니다",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping
-    public SliceResponse<FindReviewsResponse> findReviews(
+    @GetMapping(value = "/v1/reviews", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public SliceResponse<FindReviewsResponse> findReviewsV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "필터 - 특정 회원이 작성한 리뷰만 조회",
@@ -145,8 +146,8 @@ public class ReviewController {
                     """,
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/feed")
-    public SliceResponse<FindReviewFeedResponse> findReviewFeed(
+    @GetMapping(value = "/v1/reviews/feed", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public SliceResponse<FindReviewFeedResponse> findReviewFeedV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "페이지 번호 (0부터 시작합니다). 기본값은 0입니다.",
@@ -167,8 +168,8 @@ public class ReviewController {
                           "<p>정렬 기준은 최근 등록된 순(최신순)입니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping("/me")
-    public SliceResponse<FindReviewsWrittenByMeResponse> findReviewsWrittenByMe(
+    @GetMapping(value = "/v1/reviews/me", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public SliceResponse<FindReviewsWrittenByMeResponse> findReviewsWrittenByMeV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "페이지 번호 (0부터 시작합니다). 기본값은 0입니다.",
@@ -189,8 +190,8 @@ public class ReviewController {
             description = "사용자로부터 장소에 대한 키워드, 메뉴에 대한 키워드들을 받아 리뷰 내용을 자동으로 작성합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
-    @GetMapping(value = "/contents/auto-creations")
-    public GettingAutoCreatedReviewContentResponse getAutoCreatedContentWithGpt(
+    @GetMapping(value = "/v1/reviews/contents/auto-creations", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public GettingAutoCreatedReviewContentResponse getAutoCreatedContentWithGptV1_1(
             @Parameter(
                     description = """ 
                             <p>리뷰 키워드. 목록은 다음과 같다.</p>
@@ -253,8 +254,8 @@ public class ReviewController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = ReviewResponse.class))),
             @ApiResponse(description = "[3503] 리뷰 수정 권한이 없는 경우.", responseCode = "403", content = @Content)
     })
-    @PatchMapping("/{reviewId}")
-    public ReviewResponse update(
+    @PatchMapping(value = "/v1/reviews/{reviewId}", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public ReviewResponse updateV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "수정할 리뷰의 PK",
@@ -274,8 +275,8 @@ public class ReviewController {
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema)),
             @ApiResponse(description = "[3502] 리뷰 삭제 권한이 없는 경우", responseCode = "403", content = @Content)
     })
-    @DeleteMapping("/{reviewId}")
-    public void delete(
+    @DeleteMapping(value = "/v1/reviews/{reviewId}", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
+    public void deleteV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(
                     description = "삭제할 리뷰의 PK",

--- a/src/main/java/com/zelusik/eatery/controller/TermsInfoController.java
+++ b/src/main/java/com/zelusik/eatery/controller/TermsInfoController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import java.net.URI;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
+
 @Tag(name = "회원 약관 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -40,7 +42,7 @@ public class TermsInfoController {
             @ApiResponse(description = "OK", responseCode = "201", content = @Content(schema = @Schema(implementation = AgreeToTermsResponse.class))),
             @ApiResponse(description = "[1200] 필수 이용 약관이 `false`로 전달된 경우", responseCode = "422", content = @Content)
     })
-    @PostMapping(value = "/v1/members/terms", headers = "Eatery-API-Minor-Version=1")
+    @PostMapping(value = "/v1/members/terms", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public ResponseEntity<AgreeToTermsResponse> saveTermsInfoV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody AgreeToTermsRequest request

--- a/src/main/java/com/zelusik/eatery/controller/TermsInfoController.java
+++ b/src/main/java/com/zelusik/eatery/controller/TermsInfoController.java
@@ -23,9 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import java.net.URI;
 
-@Tag(name = "회원 약관 동의 관련 API")
+@Tag(name = "회원 약관 관련 API")
 @RequiredArgsConstructor
-@RequestMapping("/api/members/terms")
+@RequestMapping("/api")
 @RestController
 public class TermsInfoController {
 
@@ -40,14 +40,14 @@ public class TermsInfoController {
             @ApiResponse(description = "OK", responseCode = "201", content = @Content(schema = @Schema(implementation = AgreeToTermsResponse.class))),
             @ApiResponse(description = "[1200] 필수 이용 약관이 `false`로 전달된 경우", responseCode = "422", content = @Content)
     })
-    @PostMapping
-    public ResponseEntity<AgreeToTermsResponse> saveTermsInfo(
+    @PostMapping(value = "/v1/members/terms", headers = "Eatery-API-Minor-Version=1")
+    public ResponseEntity<AgreeToTermsResponse> saveTermsInfoV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody AgreeToTermsRequest request
     ) {
         TermsInfoDto termsInfoDto = termsInfoService.saveTermsInfo(userPrincipal.getMemberId(), request);
         return ResponseEntity
-                .created(URI.create("/api/members/terms/" + termsInfoDto.getId()))
+                .created(URI.create("/api/v1/members/terms/" + termsInfoDto.getId()))
                 .body(AgreeToTermsResponse.from(termsInfoDto));
     }
 }

--- a/src/main/java/com/zelusik/eatery/dto/bookmark/BookmarkDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/bookmark/BookmarkDto.java
@@ -4,10 +4,12 @@ import com.zelusik.eatery.domain.Bookmark;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class BookmarkDto {
 
@@ -15,12 +17,8 @@ public class BookmarkDto {
     private Long memberId;
     private Long placeId;
 
-    public static BookmarkDto of(Long id, Long memberId, Long placeId) {
-        return new BookmarkDto(id, memberId, placeId);
-    }
-
     public static BookmarkDto from(Bookmark entity) {
-        return of(
+        return new BookmarkDto(
                 entity.getId(),
                 entity.getMember().getId(),
                 entity.getPlace().getId()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,7 @@ web-scraping.server.url=${WEB_SCRAPING_SERVER_URL}
 eatery.web.prod.url=${EATERY_WEB_PROD_URL}
 eatery.web.dev.url=${EATERY_WEB_DEV_URL}
 
+springdoc.swagger-ui.operations-sorter=method
 springdoc.use-fqn=true
 
 logging.level.com.zelusik.eatery=debug

--- a/src/test/java/com/zelusik/eatery/integration/controller/MenuKeywordControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/controller/MenuKeywordControllerTest.java
@@ -67,7 +67,7 @@ class MenuKeywordControllerTest {
         );
 
         // when
-        List<MenuKeywordResponse> actualResults = sut.getMenuKeywords("음식점 > 양식 > 햄버거", List.of("까스버거", "버거", "특이한거")).getMenuKeywords();
+        List<MenuKeywordResponse> actualResults = sut.getMenuKeywordsV1_1("음식점 > 양식 > 햄버거", List.of("까스버거", "버거", "특이한거")).getMenuKeywords();
 
         // then
         assertThat(actualResults).isNotEmpty();

--- a/src/test/java/com/zelusik/eatery/unit/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/BookmarkControllerTest.java
@@ -1,0 +1,119 @@
+package com.zelusik.eatery.unit.controller;
+
+import com.zelusik.eatery.config.TestSecurityConfig;
+import com.zelusik.eatery.constant.ConstantUtil;
+import com.zelusik.eatery.constant.FoodCategoryValue;
+import com.zelusik.eatery.constant.member.Gender;
+import com.zelusik.eatery.constant.member.LoginType;
+import com.zelusik.eatery.constant.member.RoleType;
+import com.zelusik.eatery.controller.BookmarkController;
+import com.zelusik.eatery.dto.bookmark.BookmarkDto;
+import com.zelusik.eatery.dto.member.MemberDto;
+import com.zelusik.eatery.security.UserPrincipal;
+import com.zelusik.eatery.service.BookmarkService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("[Unit] Bookmark Controller Test")
+@Import(TestSecurityConfig.class)
+@WebMvcTest(controllers = BookmarkController.class)
+class BookmarkControllerTest {
+
+    @MockBean
+    private BookmarkService bookmarkService;
+
+    private final MockMvc mvc;
+
+    @Autowired
+    public BookmarkControllerTest(MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("북마크에 저장하고자 하는 장소의 id가 주어지고, 장소를 북마크에 저장하면, 저장된 북마크 정보가 반환된다.")
+    @Test
+    void givenPlaceId_whenMarkPlace_thenReturnSavedBookmark() throws Exception {
+        // given
+        long loginMemberId = 1L;
+        long placeId = 2L;
+        long bookmarkId = 3L;
+        BookmarkDto expectedResult = createBookmarkDto(bookmarkId, loginMemberId, placeId);
+        given(bookmarkService.mark(loginMemberId, placeId)).willReturn(expectedResult);
+
+        // when & then
+        mvc.perform(
+                        post("/api/v1/bookmarks")
+                                .header("Eatery-API-Minor-Version", 1)
+                                .queryParam("placeId", String.valueOf(placeId))
+                                .with(user(createTestUserDetails(loginMemberId)))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(bookmarkId))
+                .andExpect(jsonPath("$.memberId").value(loginMemberId))
+                .andExpect(jsonPath("$.placeId").value(placeId))
+                .andDo(print());
+    }
+
+    @DisplayName("장소의 id가 주어지고, 해당 장소에 대한 북마크를 삭제한다.")
+    @Test
+    void givenPlaceId_whenDeletePlaceBookmark_thenDeleteBookmark() throws Exception {
+        // given
+        long loginMemberId = 1L;
+        long placeId = 2L;
+        willDoNothing().given(bookmarkService).delete(loginMemberId, placeId);
+
+        // when & then
+        mvc.perform(
+                        delete("/api/v1/bookmarks")
+                                .header("Eatery-API-Minor-Version", 1)
+                                .queryParam("placeId", String.valueOf(placeId))
+                                .with(user(createTestUserDetails(loginMemberId)))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    private UserDetails createTestUserDetails(long memberId) {
+        return UserPrincipal.of(createMemberDto(memberId, Set.of(RoleType.USER)));
+    }
+
+    private MemberDto createMemberDto(Long memberId, Set<RoleType> roleTypes) {
+        return new MemberDto(
+                memberId,
+                ConstantUtil.defaultProfileImageUrl,
+                ConstantUtil.defaultProfileThumbnailImageUrl,
+                "1234567890",
+                LoginType.KAKAO,
+                roleTypes,
+                "test@test.com",
+                "test",
+                LocalDate.of(2000, 1, 1),
+                20,
+                Gender.MALE,
+                List.of(FoodCategoryValue.KOREAN),
+                null
+        );
+    }
+
+    private BookmarkDto createBookmarkDto(long bookmarkId, long memberId, long placeId) {
+        return new BookmarkDto(bookmarkId, memberId, placeId);
+    }
+}

--- a/src/test/java/com/zelusik/eatery/unit/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/BookmarkControllerTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -61,7 +62,7 @@ class BookmarkControllerTest {
         // when & then
         mvc.perform(
                         post("/api/v1/bookmarks")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("placeId", String.valueOf(placeId))
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
@@ -83,7 +84,7 @@ class BookmarkControllerTest {
         // when & then
         mvc.perform(
                         delete("/api/v1/bookmarks")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("placeId", String.valueOf(placeId))
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )

--- a/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -79,7 +80,7 @@ class MeetingPlaceControllerTest {
         // when & then
         mvc.perform(
                         get("/api/v1/meeting-places")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("page", "0")
                                 .queryParam("keyword", keyword)
                                 .with(user(createTestUserDetails()))
@@ -122,7 +123,7 @@ class MeetingPlaceControllerTest {
         // when & then
         mvc.perform(
                         get("/api/v1/meeting-places")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("page", "0")
                                 .queryParam("keyword", keyword)
                                 .with(user(createTestUserDetails()))
@@ -174,7 +175,7 @@ class MeetingPlaceControllerTest {
         // when & then
         mvc.perform(
                         get("/api/v1/meeting-places")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("page", "0")
                                 .queryParam("keyword", keyword)
                                 .with(user(createTestUserDetails()))

--- a/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
@@ -78,7 +78,8 @@ class MeetingPlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/meeting-places")
+                        get("/api/v1/meeting-places")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .queryParam("page", "0")
                                 .queryParam("keyword", keyword)
                                 .with(user(createTestUserDetails()))
@@ -120,7 +121,8 @@ class MeetingPlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/meeting-places")
+                        get("/api/v1/meeting-places")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .queryParam("page", "0")
                                 .queryParam("keyword", keyword)
                                 .with(user(createTestUserDetails()))
@@ -171,7 +173,8 @@ class MeetingPlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/meeting-places")
+                        get("/api/v1/meeting-places")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .queryParam("page", "0")
                                 .queryParam("keyword", keyword)
                                 .with(user(createTestUserDetails()))

--- a/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
@@ -37,6 +37,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -74,7 +75,7 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         get("/api/v1/members/me")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
@@ -101,7 +102,7 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         get("/api/v1/members/me/profile")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
@@ -136,7 +137,7 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         get("/api/v1/members/" + memberId + "/profile")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
                 .andExpect(status().isOk())
@@ -165,7 +166,7 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         get("/api/v1/members/search")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("keyword", searchKeyword)
                                 .with(user(createTestUserDetails(1L)))
                 )
@@ -186,7 +187,7 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         multipart(HttpMethod.PUT, "/api/v1/members")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .param("nickname", memberUpdateInfo.getNickname())
                                 .param("birthDay", memberUpdateInfo.getBirthDay().toString())
                                 .param("gender", memberUpdateInfo.getGender().toString())
@@ -207,7 +208,7 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         put("/api/v1/members/favorite-food")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(request))
                                 .with(user(createTestUserDetails(memberId)))
@@ -230,7 +231,7 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         delete("/api/v1/members")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(MemberDeletionSurveyRequest.of(surveyType)))
                                 .with(user(createTestUserDetails(memberId)))

--- a/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
@@ -73,7 +73,8 @@ class MemberControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/members/me")
+                        get("/api/v1/members/me")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
@@ -99,7 +100,8 @@ class MemberControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/members/me/profile")
+                        get("/api/v1/members/me/profile")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
@@ -133,7 +135,8 @@ class MemberControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/members/" + memberId + "/profile")
+                        get("/api/v1/members/" + memberId + "/profile")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
                 .andExpect(status().isOk())
@@ -161,7 +164,8 @@ class MemberControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/members/search")
+                        get("/api/v1/members/search")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .queryParam("keyword", searchKeyword)
                                 .with(user(createTestUserDetails(1L)))
                 )
@@ -181,7 +185,8 @@ class MemberControllerTest {
 
         // when & then
         mvc.perform(
-                        multipart(HttpMethod.PUT, "/api/members")
+                        multipart(HttpMethod.PUT, "/api/v1/members")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .param("nickname", memberUpdateInfo.getNickname())
                                 .param("birthDay", memberUpdateInfo.getBirthDay().toString())
                                 .param("gender", memberUpdateInfo.getGender().toString())
@@ -201,7 +206,8 @@ class MemberControllerTest {
 
         // when & then
         mvc.perform(
-                        put("/api/members/favorite-food")
+                        put("/api/v1/members/favorite-food")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(request))
                                 .with(user(createTestUserDetails(memberId)))
@@ -223,7 +229,8 @@ class MemberControllerTest {
 
         // when & then
         mvc.perform(
-                        delete("/api/members")
+                        delete("/api/v1/members")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(MemberDeletionSurveyRequest.of(surveyType)))
                                 .with(user(createTestUserDetails(memberId)))

--- a/src/test/java/com/zelusik/eatery/unit/controller/MenuKeywordControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MenuKeywordControllerTest.java
@@ -66,7 +66,8 @@ class MenuKeywordControllerTest {
 
         // when & then
         ResultActions resultActions = mvc.perform(
-                        get("/api/menu-keywords")
+                        get("/api/v1/menu-keywords")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .param("placeCategory", "음식점 > " + placeCategory.getFirstCategory() + " > " + placeCategory.getSecondCategory())
                                 .param("menus", menus.toArray(new String[0]))
                                 .with(user(createTestUserDetails()))

--- a/src/test/java/com/zelusik/eatery/unit/controller/MenuKeywordControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MenuKeywordControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.EnumMap;
 import java.util.List;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.constant.MenuKeywordCategory.MENU_NAME;
 import static com.zelusik.eatery.constant.MenuKeywordCategory.PLACE_CATEGORY;
 import static org.hamcrest.Matchers.hasSize;
@@ -67,7 +68,7 @@ class MenuKeywordControllerTest {
         // when & then
         ResultActions resultActions = mvc.perform(
                         get("/api/v1/menu-keywords")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .param("placeCategory", "음식점 > " + placeCategory.getFirstCategory() + " > " + placeCategory.getSecondCategory())
                                 .param("menus", menus.toArray(new String[0]))
                                 .with(user(createTestUserDetails()))

--- a/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
@@ -32,6 +32,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.constant.place.DayOfWeek.*;
 import static com.zelusik.eatery.util.PlaceTestUtils.createPlaceDto;
 import static com.zelusik.eatery.util.PlaceTestUtils.createPlaceDtoWithMarkedStatusAndImages;
@@ -74,7 +75,8 @@ class PlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        post("/api/places")
+                        post("/api/v1/places")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(placeCreateRequest))
                                 .with(user(createTestUserDetails(memberId)))
@@ -97,7 +99,8 @@ class PlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places/" + placeId)
+                        get("/api/v1/places/" + placeId)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
@@ -120,7 +123,8 @@ class PlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places")
+                        get("/api/v1/places")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .param("kakaoPid", kakaoPid)
                                 .with(user(createTestUserDetails(memberId)))
                 )
@@ -144,7 +148,8 @@ class PlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places/search")
+                        get("/api/v1/places/search")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("keyword", searchKeyword)
                                 .with(user(createTestUserDetails(1L)))
                 )
@@ -170,7 +175,8 @@ class PlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places/near")
+                        get("/api/v1/places/near")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("lat", point.getLat())
                                 .queryParam("lng", point.getLng())
                                 .queryParam("foodCategory", foodCategory.name())
@@ -195,7 +201,8 @@ class PlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places/near")
+                        get("/api/v1/places/near")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("lat", point.getLat())
                                 .queryParam("lng", point.getLng())
                                 .queryParam("preferredVibe", preferredVibe.name())
@@ -219,7 +226,8 @@ class PlaceControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places/bookmarks/filtering-keywords")
+                        get("/api/v1/places/bookmarks/filtering-keywords")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
@@ -242,7 +250,8 @@ class PlaceControllerTest {
         given(placeService.findMarkedDtos(eq(memberId), eq(filteringType), eq(filteringKeyword), any(Pageable.class))).willReturn(expectedResult);
 
         // when & then
-        mvc.perform(get("/api/places/bookmarks")
+        mvc.perform(get("/api/v1/places/bookmarks")
+                        .header(API_MINOR_VERSION_HEADER_NAME, 1)
                         .queryParam("type", filteringType.toString())
                         .queryParam("keyword", filteringKeywordDescription)
                         .with(user(createTestUserDetails(memberId)))

--- a/src/test/java/com/zelusik/eatery/unit/controller/PlaceMenusControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/PlaceMenusControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import java.util.Set;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.util.PlaceTestUtils.createPlaceMenusDto;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.mockito.BDDMockito.given;
@@ -63,11 +64,12 @@ class PlaceMenusControllerTest {
 
         // when & then
         mvc.perform(
-                        post("/api/places/" + placeId + "/menus")
+                        post("/api/v1/places/" + placeId + "/menus")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails()))
                 )
                 .andExpect(status().isCreated())
-                .andExpect(header().string("Location", "/api/places/" + placeId + "/menus"))
+                .andExpect(header().string("Location", "/api/v1/places/" + placeId + "/menus"))
                 .andExpect(jsonPath("$.id").value(placeMenusId))
                 .andExpect(jsonPath("$.placeId").value(placeId))
                 .andExpect(jsonPath("$.menus").isArray())
@@ -86,7 +88,8 @@ class PlaceMenusControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places/" + placeId + "/menus")
+                        get("/api/v1/places/" + placeId + "/menus")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails()))
                 )
                 .andExpect(status().isOk())
@@ -107,7 +110,8 @@ class PlaceMenusControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/places/menus")
+                        get("/api/v1/places/menus")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .param("kakaoPid", kakaoPid)
                                 .with(user(createTestUserDetails()))
                 )
@@ -131,7 +135,8 @@ class PlaceMenusControllerTest {
 
         // when & then
         mvc.perform(
-                        put("/api/places/" + placeId + "/menus")
+                        put("/api/v1/places/" + placeId + "/menus")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .content(mapper.writeValueAsString(requestBody))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(user(createTestUserDetails()))
@@ -156,7 +161,8 @@ class PlaceMenusControllerTest {
 
         // when & then
         mvc.perform(
-                        patch("/api/places/" + placeId + "/menus")
+                        patch("/api/v1/places/" + placeId + "/menus")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .content(mapper.writeValueAsString(requestBody))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(user(createTestUserDetails()))
@@ -177,7 +183,8 @@ class PlaceMenusControllerTest {
 
         // when & then
         mvc.perform(
-                        delete("/api/places/" + placeId + "/menus")
+                        delete("/api/v1/places/" + placeId + "/menus")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestAdminDetails()))
                 )
                 .andExpect(status().isOk());
@@ -192,7 +199,8 @@ class PlaceMenusControllerTest {
 
         // when & then
         mvc.perform(
-                        delete("/api/places/" + placeId + "/menus")
+                        delete("/api/v1/places/" + placeId + "/menus")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails()))
                 )
                 .andExpect(status().isForbidden());

--- a/src/test/java/com/zelusik/eatery/unit/controller/RecommendedReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/RecommendedReviewControllerTest.java
@@ -33,6 +33,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -73,7 +74,8 @@ class RecommendedReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        post("/api/members/recommended-reviews")
+                        post("/api/v1/members/recommended-reviews")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(request))
                                 .with(user(createTestUser(memberId)))
@@ -96,7 +98,8 @@ class RecommendedReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        post("/api/members/recommended-reviews")
+                        post("/api/v1/members/recommended-reviews")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(request))
                                 .with(user(createTestUser(memberId)))
@@ -118,7 +121,8 @@ class RecommendedReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/members/" + memberId + "/recommended-reviews")
+                        get("/api/v1/members/" + memberId + "/recommended-reviews")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUser(1L)))
                 )
                 .andExpect(status().isOk())
@@ -147,7 +151,8 @@ class RecommendedReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        put("/api/members/recommended-reviews/batch-update")
+                        put("/api/v1/members/recommended-reviews/batch-update")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(batchUpdateRecommendedReviewsRequest))
                                 .with(user(createTestUser(memberId)))
@@ -168,7 +173,8 @@ class RecommendedReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        put("/api/members/recommended-reviews/batch-update")
+                        put("/api/v1/members/recommended-reviews/batch-update")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(mapper.writeValueAsString(batchUpdateRecommendedReviewsRequest))
                                 .with(user(createTestUser(memberId)))

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.constant.review.ReviewEmbedOption.PLACE;
 import static com.zelusik.eatery.constant.review.ReviewEmbedOption.WRITER;
 import static com.zelusik.eatery.constant.review.ReviewKeywordValue.*;
@@ -89,8 +90,9 @@ class ReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        multipart("/api/reviews")
+                        multipart("/api/v1/reviews")
                                 .file(createMockMultipartFile())
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .param("placeId", String.valueOf(placeId))
                                 .param("keywords", FRESH.name(), NOISY.name())
                                 .param("autoCreatedContent", reviewCreateRequest.getAutoCreatedContent())
@@ -116,7 +118,8 @@ class ReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/reviews/" + reviewId)
+                        get("/api/v1/reviews/" + reviewId)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
                 .andExpect(status().isOk())
@@ -143,7 +146,8 @@ class ReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/reviews")
+                        get("/api/v1/reviews")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .queryParam("embed", WRITER.name(), PLACE.name())
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
@@ -164,7 +168,8 @@ class ReviewControllerTest {
         given(reviewService.findReviewReed(eq(loginMemberId), any(Pageable.class))).willReturn(expectedResult);
 
         // when & then
-        mvc.perform(get("/api/reviews/feed")
+        mvc.perform(get("/api/v1/reviews/feed")
+                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                         .with(user(createTestUserDetails(loginMemberId))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.contents", hasSize(expectedResult.getSize())))
@@ -185,7 +190,8 @@ class ReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/reviews/me")
+                        get("/api/v1/reviews/me")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
                 .andExpect(status().isOk())
@@ -213,7 +219,8 @@ class ReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/reviews/contents/auto-creations")
+                        get("/api/v1/reviews/contents/auto-creations")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .param("placeKeywords", placeKeywords.stream().map(ReviewKeywordValue::name).toList().toArray(new String[0]))
                                 .param("menus", menus.toArray(new String[0]))
                                 .param("menuKeywords", menuKeywords.toArray(new String[0]))
@@ -243,7 +250,8 @@ class ReviewControllerTest {
 
         // when & then
         mvc.perform(
-                        get("/api/reviews/contents/auto-creations")
+                        get("/api/v1/reviews/contents/auto-creations")
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .param("placeKeywords", placeKeywords.toArray(new String[0]))
                                 .param("menus", menus.toArray(new String[0]))
                                 .param("menuKeywords", menuKeywords.toArray(new String[0]))

--- a/src/test/java/com/zelusik/eatery/unit/controller/TermsInfoControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/TermsInfoControllerTest.java
@@ -67,7 +67,8 @@ class TermsInfoControllerTest {
 
         // when & then
         mvc.perform(
-                        post("/api/members/terms")
+                        post("/api/v1/members/terms")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .content(mapper.writeValueAsString(agreeToTermsRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(user(createTestUserDetails(loginMemberId)))
@@ -92,7 +93,8 @@ class TermsInfoControllerTest {
 
         // when & then
         mvc.perform(
-                        post("/api/members/terms")
+                        post("/api/v1/members/terms")
+                                .header("Eatery-API-Minor-Version", 1)
                                 .content(mapper.writeValueAsString(agreeToTermsRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(user(createTestUserDetails(loginMemberId)))

--- a/src/test/java/com/zelusik/eatery/unit/controller/TermsInfoControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/TermsInfoControllerTest.java
@@ -29,6 +29,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+import static com.zelusik.eatery.constant.ConstantUtil.API_MINOR_VERSION_HEADER_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -68,7 +69,7 @@ class TermsInfoControllerTest {
         // when & then
         mvc.perform(
                         post("/api/v1/members/terms")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .content(mapper.writeValueAsString(agreeToTermsRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(user(createTestUserDetails(loginMemberId)))
@@ -94,7 +95,7 @@ class TermsInfoControllerTest {
         // when & then
         mvc.perform(
                         post("/api/v1/members/terms")
-                                .header("Eatery-API-Minor-Version", 1)
+                                .header(API_MINOR_VERSION_HEADER_NAME, 1)
                                 .content(mapper.writeValueAsString(agreeToTermsRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(user(createTestUserDetails(loginMemberId)))


### PR DESCRIPTION
## 🔥 Related Issue
- Close #254 

## 🏃‍ Task
- API version에 따라 swagger에서 다른 group으로 보이도록 grouped open api 설정 추가
  - Springdoc에서 custom header를 사용한 api versioning은 지원이 미흡하다. 그 때문에 custom header versioning은 구별이 어려운 부분이 있다. 그룹 분할은 major version에 대해서만 진행하고, 각 minor version의 변경사항은 API 명세에 작성하는 것으로 진행하고자 한다.
  - [참고자료3](https://github.com/springdoc/springdoc-openapi/issues/1131)을 살펴보면 기본적으로 springdoc에서는 이에 대한 유용한 솔루션을 제공하지 않는다고 한다. 
  - 이에 대한 대안으로는 [참고자료4](https://github.com/springdoc/springdoc-openapi/issues/580)에서 추천한 것과 같이 endpoint가 겹치는 여러 API 중 하나에만 `@Operation`을 작성하고 나머지는 `@Hidden`을 붙이는 방법이 있다. 그 후 `@Operation`을 붙인 하나의 method에 여러 sub version들에 대한 명세를 함께 작성하는 방법을 얘기하고 있다.
- API Versioning 적용
- `SecurityConfig`에서 기존 설정된 API 접근 권한 설정에 대한 url들을 api version이 추가된 url로 수정

## 📄 Reference
1. [Springdoc - api groups(`GroupedOpenApi`) 설정 방법](https://velog.io/@suzhanlee/Swagger-GroupedOpenApi-%EC%84%A4%EC%A0%95-%EB%B0%A9%EB%B2%95)
2. [Springdoc - custom header로 구분하여 api groups를 설정하는 방법에 대해](https://github.com/springdoc/springdoc-openapi/issues/449)
3. [Springdoc - API of different headers with the same path를 구분하는 솔루션을 제공하지 않는다는 공식 답변](https://github.com/springdoc/springdoc-openapi/issues/1131)
4. [Springdoc - API의 header만 다른 경우 이러한 api들에 대한 명세 작성 방안](https://github.com/springdoc/springdoc-openapi/issues/580)
