### PR TITLE
PlaceMenus의 메뉴 목록 값 글자수 제한 증가

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/place/PlaceMenus.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/PlaceMenus.java
@@ -30,6 +30,7 @@ public class PlaceMenus extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Place place;
 
+    @Column(length = 10000)
     @Convert(converter = PlaceMenusConverter.class)
     private List<String> menus;
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #372

## 🏃‍ Task
- `PlaceMenus`의 메뉴 목록 값 글자수 제한 증가. (`VARCHAR(255)` => `VARCHAR(10000)`)

## 📄 Reference
- None
