### PR TITLE
Hotfix: 회원 entity의 email column에 대한 unique 제약조건으로 인해 회원가입이 되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/member/Member.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/Member.java
@@ -53,7 +53,6 @@ public class Member extends BaseTimeEntity {
     @Convert(converter = RoleTypesConverter.class)
     private Set<RoleType> roleTypes;
 
-    @Column(unique = true)
     private String email;
 
     @Setter(AccessLevel.PRIVATE)


### PR DESCRIPTION
## 🔥 Related Issue
- Close #379

## 🏃‍ Task
- `Member` entity의 `email` column에 대한 not null 제약조건 삭제

## 📄 Reference
- None
