### PR TITLE
Dto 중 entity에 포함되지 않은 필드를 `XxxWithXxxDto`의 별도 dto로 분리

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/member/api/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/api/MemberController.java
@@ -3,7 +3,7 @@ package com.zelusik.eatery.domain.member.api;
 import com.zelusik.eatery.domain.favorite_food_category.dto.request.FavoriteFoodCategoriesUpdateRequest;
 import com.zelusik.eatery.domain.favorite_food_category.dto.response.UpdateFavoriteFoodCategoriesResponse;
 import com.zelusik.eatery.domain.member.dto.MemberDto;
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import com.zelusik.eatery.domain.member.dto.request.MemberUpdateRequest;
 import com.zelusik.eatery.domain.member.dto.response.*;
 import com.zelusik.eatery.domain.member.service.MemberCommandService;
@@ -103,8 +103,8 @@ public class MemberController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long memberId
     ) {
-        MemberProfileInfoDto memberProfileInfoDto = memberQueryService.getMemberProfileInfoById(memberId);
-        return GetMemberProfileInfoResponse.from(userPrincipal.getMemberId(), memberProfileInfoDto);
+        MemberWithProfileInfoDto memberWithProfileInfoDto = memberQueryService.getMemberProfileInfoById(memberId);
+        return GetMemberProfileInfoResponse.from(userPrincipal.getMemberId(), memberWithProfileInfoDto);
     }
 
     @Operation(

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/MemberDto.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class MemberDto {
 

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/MemberWithProfileInfoDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/MemberWithProfileInfoDto.java
@@ -1,46 +1,64 @@
 package com.zelusik.eatery.domain.member.dto;
 
+import com.zelusik.eatery.domain.favorite_food_category.entity.FavoriteFoodCategory;
+import com.zelusik.eatery.domain.member.constant.Gender;
+import com.zelusik.eatery.domain.member.constant.LoginType;
+import com.zelusik.eatery.domain.member.constant.RoleType;
 import com.zelusik.eatery.domain.member.entity.Member;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.lang.Nullable;
 
-@AllArgsConstructor
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class MemberWithProfileInfoDto {
-
-    private MemberDto member;
+public class MemberWithProfileInfoDto extends MemberDto {
 
     private Integer numOfReviews;
-
     private Integer influence;
-
     private Integer numOfFollowers;
-
     private Integer numOfFollowings;
-
     private String mostVisitedLocation;
-
-    @Nullable
     private ReviewKeywordValue mostTaggedReviewKeyword;
-
-    @Nullable
     private FoodCategoryValue mostEatenFoodCategory;
 
-    public static MemberWithProfileInfoDto of(Member member, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostUsedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
+    public MemberWithProfileInfoDto(Long id, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, Set<RoleType> roleTypes, String email, String nickname, LocalDate birthDay, Integer ageRange, Gender gender, List<FoodCategoryValue> favoriteFoodCategories, LocalDateTime deletedAt, Integer numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
+        super(id, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, birthDay, ageRange, gender, favoriteFoodCategories, deletedAt);
+        this.numOfReviews = numOfReviews;
+        this.influence = 0; // TODO: 영향력 관련 기능 구현 후 로직 수정 필요
+        this.numOfFollowers = 0;    // TODO: 팔로우 기능 구현 후 로직 수정 필요
+        this.numOfFollowings = 0;   // TODO: 팔로우 기능 구현 후 로직 수정 필요
+        this.mostVisitedLocation = mostVisitedLocation;
+        this.mostTaggedReviewKeyword = mostTaggedReviewKeyword;
+        this.mostEatenFoodCategory = mostEatenFoodCategory;
+    }
+
+    public static MemberWithProfileInfoDto from(Member member, Integer numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
         return new MemberWithProfileInfoDto(
-                MemberDto.from(member),
+                member.getId(),
+                member.getProfileImageUrl(),
+                member.getProfileThumbnailImageUrl(),
+                member.getSocialUid(),
+                member.getLoginType(),
+                member.getRoleTypes(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getBirthDay(),
+                member.getAgeRange(),
+                member.getGender(),
+                member.getFavoriteFoodCategories().stream()
+                        .map(FavoriteFoodCategory::getCategory)
+                        .toList(),
+                member.getDeletedAt(),
                 numOfReviews,
-                0,  // TODO: 영향력 관련 기능 구현 후 로직 수정 필요
-                0,  // TODO: 팔로우 기능 구현 후 로직 수정 필요
-                0,  // TODO: 팔로우 기능 구현 후 로직 수정 필요
                 mostVisitedLocation,
-                mostUsedReviewKeyword,
+                mostTaggedReviewKeyword,
                 mostEatenFoodCategory
         );
     }

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/MemberWithProfileInfoDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/MemberWithProfileInfoDto.java
@@ -1,33 +1,20 @@
 package com.zelusik.eatery.domain.member.dto;
 
-import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
-import com.zelusik.eatery.domain.member.constant.Gender;
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.member.entity.Member;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 
-import java.time.LocalDate;
-
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class MemberProfileInfoDto {
+public class MemberWithProfileInfoDto {
 
-    private Long id;
-
-    private String profileImageUrl;
-
-    private String profileThumbnailImageUrl;
-
-    private String nickname;
-
-    private Gender gender;
-
-    private LocalDate birthDay;
+    private MemberDto member;
 
     private Integer numOfReviews;
 
@@ -45,14 +32,9 @@ public class MemberProfileInfoDto {
     @Nullable
     private FoodCategoryValue mostEatenFoodCategory;
 
-    public static MemberProfileInfoDto of(Member member, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostUsedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
-        return new MemberProfileInfoDto(
-                member.getId(),
-                member.getProfileImageUrl(),
-                member.getProfileThumbnailImageUrl(),
-                member.getNickname(),
-                member.getGender(),
-                member.getBirthDay(),
+    public static MemberWithProfileInfoDto of(Member member, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostUsedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
+        return new MemberWithProfileInfoDto(
+                MemberDto.from(member),
                 numOfReviews,
                 0,  // TODO: 영향력 관련 기능 구현 후 로직 수정 필요
                 0,  // TODO: 팔로우 기능 구현 후 로직 수정 필요

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMemberProfileInfoResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMemberProfileInfoResponse.java
@@ -1,6 +1,5 @@
 package com.zelusik.eatery.domain.member.dto.response;
 
-import com.zelusik.eatery.domain.member.dto.MemberDto;
 import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -41,15 +40,14 @@ public class GetMemberProfileInfoResponse {
     private MemberTasteStatisticsResponse tasteStatistics;
 
     public static GetMemberProfileInfoResponse from(long loginMemberId, MemberWithProfileInfoDto memberWithProfileInfoDto) {
-        MemberDto member = memberWithProfileInfoDto.getMember();
         return new GetMemberProfileInfoResponse(
-                member.getId(),
-                loginMemberId == member.getId(),
+                memberWithProfileInfoDto.getId(),
+                loginMemberId == memberWithProfileInfoDto.getId(),
                 new MemberProfileImageResponse(
-                        member.getProfileImageUrl(),
-                        member.getProfileThumbnailImageUrl()
+                        memberWithProfileInfoDto.getProfileImageUrl(),
+                        memberWithProfileInfoDto.getProfileThumbnailImageUrl()
                 ),
-                member.getNickname(),
+                memberWithProfileInfoDto.getNickname(),
                 memberWithProfileInfoDto.getNumOfReviews(),
                 memberWithProfileInfoDto.getInfluence(),
                 memberWithProfileInfoDto.getNumOfFollowers(),

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMemberProfileInfoResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMemberProfileInfoResponse.java
@@ -1,6 +1,7 @@
 package com.zelusik.eatery.domain.member.dto.response;
 
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,23 +40,24 @@ public class GetMemberProfileInfoResponse {
     @Schema(description = "취향 통계 정보")
     private MemberTasteStatisticsResponse tasteStatistics;
 
-    public static GetMemberProfileInfoResponse from(long loginMemberId, MemberProfileInfoDto memberProfileInfoDto) {
+    public static GetMemberProfileInfoResponse from(long loginMemberId, MemberWithProfileInfoDto memberWithProfileInfoDto) {
+        MemberDto member = memberWithProfileInfoDto.getMember();
         return new GetMemberProfileInfoResponse(
-                memberProfileInfoDto.getId(),
-                loginMemberId == memberProfileInfoDto.getId(),
+                member.getId(),
+                loginMemberId == member.getId(),
                 new MemberProfileImageResponse(
-                        memberProfileInfoDto.getProfileImageUrl(),
-                        memberProfileInfoDto.getProfileThumbnailImageUrl()
+                        member.getProfileImageUrl(),
+                        member.getProfileThumbnailImageUrl()
                 ),
-                memberProfileInfoDto.getNickname(),
-                memberProfileInfoDto.getNumOfReviews(),
-                memberProfileInfoDto.getInfluence(),
-                memberProfileInfoDto.getNumOfFollowers(),
-                memberProfileInfoDto.getNumOfFollowings(),
+                member.getNickname(),
+                memberWithProfileInfoDto.getNumOfReviews(),
+                memberWithProfileInfoDto.getInfluence(),
+                memberWithProfileInfoDto.getNumOfFollowers(),
+                memberWithProfileInfoDto.getNumOfFollowings(),
                 new MemberTasteStatisticsResponse(
-                        memberProfileInfoDto.getMostVisitedLocation(),
-                        memberProfileInfoDto.getMostTaggedReviewKeyword() != null ? memberProfileInfoDto.getMostTaggedReviewKeyword().getContent() : "",
-                        memberProfileInfoDto.getMostEatenFoodCategory() != null ? memberProfileInfoDto.getMostEatenFoodCategory().getCategoryName() : ""
+                        memberWithProfileInfoDto.getMostVisitedLocation(),
+                        memberWithProfileInfoDto.getMostTaggedReviewKeyword() != null ? memberWithProfileInfoDto.getMostTaggedReviewKeyword().getContent() : "",
+                        memberWithProfileInfoDto.getMostEatenFoodCategory() != null ? memberWithProfileInfoDto.getMostEatenFoodCategory().getCategoryName() : ""
                 )
         );
     }

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMyProfileInfoResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMyProfileInfoResponse.java
@@ -1,6 +1,7 @@
 package com.zelusik.eatery.domain.member.dto.response;
 
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -44,24 +45,25 @@ public class GetMyProfileInfoResponse {
     @Schema(description = "취향 통계 정보")
     private MemberTasteStatisticsResponse tasteStatistics;
 
-    public static GetMyProfileInfoResponse from(MemberProfileInfoDto memberProfileInfoDto) {
+    public static GetMyProfileInfoResponse from(MemberWithProfileInfoDto memberWithProfileInfoDto) {
+        MemberDto member = memberWithProfileInfoDto.getMember();
         return new GetMyProfileInfoResponse(
-                memberProfileInfoDto.getId(),
+                member.getId(),
                 new MemberProfileImageResponse(
-                        memberProfileInfoDto.getProfileImageUrl(),
-                        memberProfileInfoDto.getProfileThumbnailImageUrl()
+                        member.getProfileImageUrl(),
+                        member.getProfileThumbnailImageUrl()
                 ),
-                memberProfileInfoDto.getNickname(),
-                memberProfileInfoDto.getGender().getDescription(),
-                memberProfileInfoDto.getBirthDay(),
-                memberProfileInfoDto.getNumOfReviews(),
-                memberProfileInfoDto.getInfluence(),
-                memberProfileInfoDto.getNumOfFollowers(),
-                memberProfileInfoDto.getNumOfFollowings(),
+                member.getNickname(),
+                member.getGender().getDescription(),
+                member.getBirthDay(),
+                memberWithProfileInfoDto.getNumOfReviews(),
+                memberWithProfileInfoDto.getInfluence(),
+                memberWithProfileInfoDto.getNumOfFollowers(),
+                memberWithProfileInfoDto.getNumOfFollowings(),
                 new MemberTasteStatisticsResponse(
-                        memberProfileInfoDto.getMostVisitedLocation(),
-                        memberProfileInfoDto.getMostTaggedReviewKeyword() != null ? memberProfileInfoDto.getMostTaggedReviewKeyword().getContent() : "",
-                        memberProfileInfoDto.getMostEatenFoodCategory() != null ? memberProfileInfoDto.getMostEatenFoodCategory().getCategoryName() : ""
+                        memberWithProfileInfoDto.getMostVisitedLocation(),
+                        memberWithProfileInfoDto.getMostTaggedReviewKeyword() != null ? memberWithProfileInfoDto.getMostTaggedReviewKeyword().getContent() : "",
+                        memberWithProfileInfoDto.getMostEatenFoodCategory() != null ? memberWithProfileInfoDto.getMostEatenFoodCategory().getCategoryName() : ""
                 )
         );
     }

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMyProfileInfoResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/response/GetMyProfileInfoResponse.java
@@ -1,6 +1,5 @@
 package com.zelusik.eatery.domain.member.dto.response;
 
-import com.zelusik.eatery.domain.member.dto.MemberDto;
 import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -46,16 +45,15 @@ public class GetMyProfileInfoResponse {
     private MemberTasteStatisticsResponse tasteStatistics;
 
     public static GetMyProfileInfoResponse from(MemberWithProfileInfoDto memberWithProfileInfoDto) {
-        MemberDto member = memberWithProfileInfoDto.getMember();
         return new GetMyProfileInfoResponse(
-                member.getId(),
+                memberWithProfileInfoDto.getId(),
                 new MemberProfileImageResponse(
-                        member.getProfileImageUrl(),
-                        member.getProfileThumbnailImageUrl()
+                        memberWithProfileInfoDto.getProfileImageUrl(),
+                        memberWithProfileInfoDto.getProfileThumbnailImageUrl()
                 ),
-                member.getNickname(),
-                member.getGender().getDescription(),
-                member.getBirthDay(),
+                memberWithProfileInfoDto.getNickname(),
+                memberWithProfileInfoDto.getGender().getDescription(),
+                memberWithProfileInfoDto.getBirthDay(),
                 memberWithProfileInfoDto.getNumOfReviews(),
                 memberWithProfileInfoDto.getInfluence(),
                 memberWithProfileInfoDto.getNumOfFollowers(),

--- a/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustom.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.domain.member.repository;
 
 import com.zelusik.eatery.domain.member.entity.Member;
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -24,7 +24,7 @@ public interface MemberRepositoryQCustom {
      * @param memberId 프로필 정보를 조회할 회원의 PK
      * @return 조회된 프로필 정보
      */
-    MemberProfileInfoDto getMemberProfileInfoById(long memberId);
+    MemberWithProfileInfoDto getMemberProfileInfoById(long memberId);
 
     /**
      * 주어진 키워드에 해당하는 닉네임을 갖는 회원을 검색한다..

--- a/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustomImpl.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.domain.member.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zelusik.eatery.domain.member.entity.QMember;
 import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.member.entity.Member;
@@ -29,16 +30,16 @@ public class MemberRepositoryQCustomImpl implements MemberRepositoryQCustom {
 
     @Override
     public MemberWithProfileInfoDto getMemberProfileInfoById(long memberId) {
-        Member foundMember = Optional.ofNullable(
+        Member member = Optional.ofNullable(
                 queryFactory
-                        .select(member)
-                        .from(member)
-                        .where(isMemberNotDeleted(), member.id.eq(memberId))
+                        .select(QMember.member)
+                        .from(QMember.member)
+                        .where(isMemberNotDeleted(), QMember.member.id.eq(memberId))
                         .fetchOne()
         ).orElseThrow(() -> new MemberIdNotFoundException(memberId));
 
-        return MemberWithProfileInfoDto.of(
-                foundMember,
+        return MemberWithProfileInfoDto.from(
+                member,
                 getNumOfReviews(memberId),
                 getMostVisitedLocation(memberId),
                 getMostTaggedReviewKeyword(memberId),

--- a/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustomImpl.java
@@ -6,7 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.member.entity.Member;
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import com.zelusik.eatery.domain.member.exception.MemberIdNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +28,7 @@ public class MemberRepositoryQCustomImpl implements MemberRepositoryQCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public MemberProfileInfoDto getMemberProfileInfoById(long memberId) {
+    public MemberWithProfileInfoDto getMemberProfileInfoById(long memberId) {
         Member foundMember = Optional.ofNullable(
                 queryFactory
                         .select(member)
@@ -37,7 +37,7 @@ public class MemberRepositoryQCustomImpl implements MemberRepositoryQCustom {
                         .fetchOne()
         ).orElseThrow(() -> new MemberIdNotFoundException(memberId));
 
-        return MemberProfileInfoDto.of(
+        return MemberWithProfileInfoDto.of(
                 foundMember,
                 getNumOfReviews(memberId),
                 getMostVisitedLocation(memberId),

--- a/src/main/java/com/zelusik/eatery/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/service/MemberQueryService.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.domain.member.service;
 
 import com.zelusik.eatery.domain.member.dto.MemberDto;
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import com.zelusik.eatery.domain.member.entity.Member;
 import com.zelusik.eatery.domain.member.exception.MemberIdNotFoundException;
 import com.zelusik.eatery.domain.member.repository.MemberRepository;
@@ -83,7 +83,7 @@ public class MemberQueryService {
      * @param memberId 프로필 정보를 조회할 회원의 PK
      * @return 조회된 프로필 정보
      */
-    public MemberProfileInfoDto getMemberProfileInfoById(long memberId) {
+    public MemberWithProfileInfoDto getMemberProfileInfoById(long memberId) {
         return memberRepository.getMemberProfileInfoById(memberId);
     }
 }

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/PlaceDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/PlaceDto.java
@@ -1,74 +1,45 @@
 package com.zelusik.eatery.domain.place.dto;
 
-import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.opening_hours.dto.OpeningHoursDto;
+import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
 
 import java.util.List;
 
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PlaceDto {
 
     private Long id;
-
     private List<ReviewKeywordValue> top3Keywords;
-
     private String kakaoPid;
-
     private String name;
-
     private String pageUrl;
-
     private KakaoCategoryGroupCode categoryGroupCode;
-
     private PlaceCategory category;
-
-    @Nullable
     private String phone;
-
     private Address address;
-
-    @Nullable
     private String homepageUrl;
-
     private Point point;
-
-    @Nullable
     private String closingHours;
-
-    @Nullable
-    private List<OpeningHoursDto> openingHoursDtos;
-
-    @Nullable
-    private List<ReviewImageDto> images;
-
-    @Nullable
-    private Boolean isMarked;
+    private List<OpeningHoursDto> openingHours;
 
     public PlaceDto(String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours) {
-        this(null, null, kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, null, null, null);
+        this(null, null, kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, null);
     }
 
     @NonNull
-    public static PlaceDto from(@NonNull Place place, @Nullable Boolean isMarked) {
-        return fromWithImages(place, isMarked, null);
-    }
-
-    @NonNull
-    public static PlaceDto fromWithImages(@NonNull Place place, @Nullable Boolean isMarked, @Nullable List<ReviewImageDto> images) {
+    public static PlaceDto from(@NonNull Place place) {
         return new PlaceDto(
                 place.getId(),
                 place.getTop3Keywords(),
@@ -84,15 +55,8 @@ public class PlaceDto {
                 place.getClosingHours(),
                 place.getOpeningHoursList().stream()
                         .map(OpeningHoursDto::from)
-                        .toList(),
-                images,
-                isMarked
+                        .toList()
         );
-    }
-
-    @NonNull
-    public static PlaceDto fromWithoutMarkedStatusAndImages(@NonNull Place place) {
-        return from(place, null);
     }
 
     @NonNull

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/PlaceWithMarkedStatusAndImagesDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/PlaceWithMarkedStatusAndImagesDto.java
@@ -1,0 +1,50 @@
+package com.zelusik.eatery.domain.place.dto;
+
+import com.zelusik.eatery.domain.opening_hours.dto.OpeningHoursDto;
+import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
+import com.zelusik.eatery.domain.place.entity.Address;
+import com.zelusik.eatery.domain.place.entity.Place;
+import com.zelusik.eatery.domain.place.entity.PlaceCategory;
+import com.zelusik.eatery.domain.place.entity.Point;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class PlaceWithMarkedStatusAndImagesDto extends PlaceDto {
+
+    private Boolean isMarked;
+    private List<ReviewImageDto> images;
+
+    public PlaceWithMarkedStatusAndImagesDto(Long id, List<ReviewKeywordValue> top3Keywords, String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours, List<OpeningHoursDto> openingHours, Boolean isMarked, List<ReviewImageDto> images) {
+        super(id, top3Keywords, kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, openingHours);
+        this.isMarked = isMarked;
+        this.images = images;
+    }
+
+    public static PlaceWithMarkedStatusAndImagesDto from(Place place, boolean isMarked, List<ReviewImageDto> images) {
+        return new PlaceWithMarkedStatusAndImagesDto(
+                place.getId(),
+                place.getTop3Keywords(),
+                place.getKakaoPid(),
+                place.getName(),
+                place.getPageUrl(),
+                place.getCategoryGroupCode(),
+                place.getCategory(),
+                place.getPhone(),
+                place.getAddress(),
+                place.getHomepageUrl(),
+                place.getPoint(),
+                place.getClosingHours(),
+                place.getOpeningHoursList().stream()
+                        .map(OpeningHoursDto::from)
+                        .toList(),
+                isMarked,
+                images);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/PlaceWithMarkedStatusDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/PlaceWithMarkedStatusDto.java
@@ -1,0 +1,46 @@
+package com.zelusik.eatery.domain.place.dto;
+
+import com.zelusik.eatery.domain.opening_hours.dto.OpeningHoursDto;
+import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
+import com.zelusik.eatery.domain.place.entity.Address;
+import com.zelusik.eatery.domain.place.entity.Place;
+import com.zelusik.eatery.domain.place.entity.PlaceCategory;
+import com.zelusik.eatery.domain.place.entity.Point;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class PlaceWithMarkedStatusDto extends PlaceDto {
+
+    private Boolean isMarked;
+
+    public PlaceWithMarkedStatusDto(Long id, List<ReviewKeywordValue> top3Keywords, String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours, List<OpeningHoursDto> openingHours, Boolean isMarked) {
+        super(id, top3Keywords, kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, openingHours);
+        this.isMarked = isMarked;
+    }
+
+    public static PlaceWithMarkedStatusDto from(Place place, boolean isMarked) {
+        return new PlaceWithMarkedStatusDto(
+                place.getId(),
+                place.getTop3Keywords(),
+                place.getKakaoPid(),
+                place.getName(),
+                place.getPageUrl(),
+                place.getCategoryGroupCode(),
+                place.getCategory(),
+                place.getPhone(),
+                place.getAddress(),
+                place.getHomepageUrl(),
+                place.getPoint(),
+                place.getClosingHours(),
+                place.getOpeningHoursList().stream()
+                        .map(OpeningHoursDto::from)
+                        .toList(),
+                isMarked);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/response/FindMarkedPlacesResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/response/FindMarkedPlacesResponse.java
@@ -1,8 +1,8 @@
 package com.zelusik.eatery.domain.place.dto.response;
 
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusAndImagesDto;
 import com.zelusik.eatery.domain.place.entity.Address;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -39,7 +39,7 @@ public class FindMarkedPlacesResponse {
     @Schema(description = "장소에 대표 이미지(최대 4개)")
     private List<PlaceImageResponse> images;
 
-    public static FindMarkedPlacesResponse from(PlaceDto dto) {
+    public static FindMarkedPlacesResponse from(PlaceWithMarkedStatusAndImagesDto dto) {
         String category = dto.getCategory().getSecondCategory();
         if (category == null) {
             category = dto.getCategory().getFirstCategory();

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/response/FindNearPlacesResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/response/FindNearPlacesResponse.java
@@ -1,9 +1,9 @@
 package com.zelusik.eatery.domain.place.dto.response;
 
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusAndImagesDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -22,7 +22,7 @@ public class FindNearPlacesResponse {
     private Long id;
 
     @Schema(description = "<p>가장 많이 태그된 top 3 keywords." +
-            "<p>이 장소에 대한 리뷰가 없다면, empty array로 응답합니다.",
+                          "<p>이 장소에 대한 리뷰가 없다면, empty array로 응답합니다.",
             example = "[\"신선한 재료\", \"최고의 맛\"]")
     List<String> top3Keywords;
 
@@ -44,7 +44,7 @@ public class FindNearPlacesResponse {
     @Schema(description = "북마크 여부", example = "false")
     private Boolean isMarked;
 
-    public static FindNearPlacesResponse from(PlaceDto dto) {
+    public static FindNearPlacesResponse from(PlaceWithMarkedStatusAndImagesDto dto) {
         String category = dto.getCategory().getSecondCategory();
         if (category == null) {
             category = dto.getCategory().getFirstCategory();

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/response/FindPlaceResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/response/FindPlaceResponse.java
@@ -1,15 +1,16 @@
 package com.zelusik.eatery.domain.place.dto.response;
 
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusAndImagesDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -57,9 +58,9 @@ public class FindPlaceResponse {
     @Schema(description = "북마크 여부", example = "false")
     private Boolean isMarked;
 
-    public static FindPlaceResponse from(PlaceDto dto) {
+    public static FindPlaceResponse from(PlaceWithMarkedStatusAndImagesDto dto) {
         String snsUrl = dto.getHomepageUrl();
-        if (snsUrl != null && !snsUrl.contains("instagram")) {
+        if (!StringUtils.hasText(snsUrl) || !snsUrl.contains("instagram")) {
             snsUrl = null;
         }
 
@@ -71,8 +72,8 @@ public class FindPlaceResponse {
         }
 
         List<String> openingHours = List.of();
-        if (dto.getOpeningHoursDtos() != null && !dto.getOpeningHoursDtos().isEmpty()) {
-            openingHours = dto.getOpeningHoursDtos().stream()
+        if (dto.getOpeningHours() != null && !dto.getOpeningHours().isEmpty()) {
+            openingHours = dto.getOpeningHours().stream()
                     .map(oh -> String.format(oh.getDayOfWeek().getDescription() + " " + oh.getOpenAt() + "-" + oh.getCloseAt()))
                     .toList();
         }

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/response/PlaceCompactResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/response/PlaceCompactResponse.java
@@ -1,8 +1,8 @@
 package com.zelusik.eatery.domain.place.dto.response;
 
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,7 +19,7 @@ public class PlaceCompactResponse {
 
     @Schema(
             description = "<p>가장 많이 태그된 top 3 keywords." +
-                    "<p>이 장소에 대한 리뷰가 없다면, empty array로 응답합니다.",
+                          "<p>이 장소에 대한 리뷰가 없다면, empty array로 응답합니다.",
             example = "[\"신선한 재료\", \"최고의 맛\"]"
     )
     List<String> top3Keywords;
@@ -40,7 +40,7 @@ public class PlaceCompactResponse {
         return new PlaceCompactResponse(id, top3Keywords, name, category, address, isMarked);
     }
 
-    public static PlaceCompactResponse from(PlaceDto dto) {
+    public static PlaceCompactResponse from(PlaceWithMarkedStatusDto dto) {
         String category = dto.getCategory().getSecondCategory();
         if (category == null) {
             category = dto.getCategory().getFirstCategory();

--- a/src/main/java/com/zelusik/eatery/domain/place/dto/response/SavePlaceResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/dto/response/SavePlaceResponse.java
@@ -1,28 +1,24 @@
 package com.zelusik.eatery.domain.place.dto.response;
 
-import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
+import com.zelusik.eatery.domain.place.dto.PlaceDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class PlaceResponse {
+public class SavePlaceResponse {
 
     @Schema(description = "장소의 id(PK)", example = "1")
     private Long id;
-
-    @Schema(description = "<p>가장 많이 태그된 top 3 keywords." +
-                          "<p>이 장소에 대한 리뷰가 없다면, empty array로 응답합니다.",
-            example = "[\"신선한 재료\", \"최고의 맛\"]")
-    List<String> top3Keywords;
 
     @Schema(description = "이름", example = "연남토마 본점")
     private String name;
@@ -45,7 +41,7 @@ public class PlaceResponse {
     @Schema(description = "휴무일", example = "금요일")
     private String closingHours;
 
-    @Schema(description = "영업시간 정보", example = """
+    @Schema(description = "영업 시간 정보", example = """
             [
                 "월 11:30-22:00",
                 "화 11:30-22:00",
@@ -56,14 +52,7 @@ public class PlaceResponse {
             """)
     private List<String> openingHours;
 
-    @Schema(description = "북마크 여부", example = "false")
-    private Boolean isMarked;
-
-    public static PlaceResponse of(Long id, List<String> top3Keywords, String name, String category, String phone, Address address, String snsUrl, Point point, String closingHours, List<String> openingHours, Boolean isMarked) {
-        return new PlaceResponse(id, top3Keywords, name, category, phone, address, snsUrl, point, closingHours, openingHours, isMarked);
-    }
-
-    public static PlaceResponse from(PlaceWithMarkedStatusDto dto) {
+    public static SavePlaceResponse from(PlaceDto dto) {
         String snsUrl = dto.getHomepageUrl();
         if (!StringUtils.hasText(snsUrl) || !snsUrl.contains("instagram")) {
             snsUrl = null;
@@ -78,11 +67,8 @@ public class PlaceResponse {
                 .map(oh -> String.format(oh.getDayOfWeek().getDescription() + " " + oh.getOpenAt() + "-" + oh.getCloseAt()))
                 .toList();
 
-        return new PlaceResponse(
+        return new SavePlaceResponse(
                 dto.getId(),
-                dto.getTop3Keywords().stream()
-                        .map(ReviewKeywordValue::getContent)
-                        .toList(),
                 dto.getName(),
                 category,
                 dto.getPhone(),
@@ -90,8 +76,7 @@ public class PlaceResponse {
                 snsUrl,
                 dto.getPoint(),
                 dto.getClosingHours(),
-                openingHours,
-                dto.getIsMarked()
+                openingHours
         );
     }
 }

--- a/src/main/java/com/zelusik/eatery/domain/place/repository/PlaceRepositoryJCustom.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/repository/PlaceRepositoryJCustom.java
@@ -1,9 +1,9 @@
 package com.zelusik.eatery.domain.place.repository;
 
 import com.zelusik.eatery.domain.place.constant.FilteringType;
-import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusAndImagesDto;
 import com.zelusik.eatery.domain.place.dto.request.FindNearPlacesFilteringConditionRequest;
+import com.zelusik.eatery.domain.place.entity.Point;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +11,7 @@ public interface PlaceRepositoryJCustom {
 
     /**
      * 중심 좌표 기준, 가까운 순으로 장소 목록을 조회한다.
+     * 영업 시간 정보는 함께 조회하지 않는다.
      *
      * @param loginMemberId      PK of login member
      * @param filteringCondition 필터링 조건
@@ -20,11 +21,12 @@ public interface PlaceRepositoryJCustom {
      * @param pageable           paging 정보
      * @return 조회한 장소 목록
      */
-    Page<PlaceDto> findDtosNearBy(long loginMemberId, FindNearPlacesFilteringConditionRequest filteringCondition, Point center, int distanceLimit, int numOfPlaceImages, Pageable pageable);
+    Page<PlaceWithMarkedStatusAndImagesDto> findDtosWithoutOpeningHoursNearBy(long loginMemberId, FindNearPlacesFilteringConditionRequest filteringCondition, Point center, int distanceLimit, int numOfPlaceImages, Pageable pageable);
 
     /**
      * 북마크에 저장한 장소 목록(Slice)을 조회합니다.
-     * 정렬 기준은 최근에 저장한 순서입니다.
+     * 정렬 기준은 최근에 저장한 순서이다.
+     * 영업 시간 정보는 함께 조회하지 않는다.
      *
      * @param memberId         장소를 조회하고자 하는 회원의 PK
      * @param filteringKeyword filtering keyword
@@ -33,5 +35,5 @@ public interface PlaceRepositoryJCustom {
      * @param pageable         paging 정보
      * @return 조회된 장소 목록
      */
-    Page<PlaceDto> findMarkedPlaces(Long memberId, FilteringType filteringType, String filteringKeyword, int numOfPlaceImages, Pageable pageable);
+    Page<PlaceWithMarkedStatusAndImagesDto> findMarkedDtosWithoutOpeningHours(Long memberId, FilteringType filteringType, String filteringKeyword, int numOfPlaceImages, Pageable pageable);
 }

--- a/src/main/java/com/zelusik/eatery/domain/place/service/PlaceCommandService.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/service/PlaceCommandService.java
@@ -4,7 +4,7 @@ import com.zelusik.eatery.domain.bookmark.service.BookmarkQueryService;
 import com.zelusik.eatery.domain.opening_hours.entity.OpeningHours;
 import com.zelusik.eatery.domain.opening_hours.repository.OpeningHoursRepository;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.domain.place.dto.PlaceScrapingInfo;
+import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
 import com.zelusik.eatery.domain.place.dto.request.PlaceCreateRequest;
 import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.place.exception.PlaceAlreadyExistsException;
@@ -44,7 +44,7 @@ public class PlaceCommandService {
             throw new PlaceAlreadyExistsException(kakaoPid);
         }
 
-        PlaceScrapingInfo scrapingInfo = webScrapingService.getPlaceScrapingInfo(placeCreateRequest.getKakaoPid());
+        KakaoPlaceScrapingInfo scrapingInfo = webScrapingService.getPlaceScrapingInfo(placeCreateRequest.getKakaoPid());
 
         Place savedPlace = placeRepository.save(placeCreateRequest.toDto(scrapingInfo.getHomepageUrl(), scrapingInfo.getClosingHours()).toEntity());
         boolean placeMarkedStatus = bookmarkQueryService.isMarkedPlace(memberId, savedPlace);

--- a/src/main/java/com/zelusik/eatery/domain/place/service/PlaceCommandService.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/service/PlaceCommandService.java
@@ -1,16 +1,15 @@
 package com.zelusik.eatery.domain.place.service;
 
-import com.zelusik.eatery.domain.bookmark.service.BookmarkQueryService;
 import com.zelusik.eatery.domain.opening_hours.entity.OpeningHours;
 import com.zelusik.eatery.domain.opening_hours.repository.OpeningHoursRepository;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
 import com.zelusik.eatery.domain.place.dto.request.PlaceCreateRequest;
 import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.place.exception.PlaceAlreadyExistsException;
 import com.zelusik.eatery.domain.place.repository.PlaceRepository;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.review_keyword.repository.ReviewKeywordRepository;
+import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
 import com.zelusik.eatery.global.scraping.exception.ScrapingServerInternalError;
 import com.zelusik.eatery.global.scraping.service.WebScrapingService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,6 @@ public class PlaceCommandService {
     private final WebScrapingService webScrapingService;
     private final PlaceRepository placeRepository;
     private final OpeningHoursRepository openingHoursRepository;
-    private final BookmarkQueryService bookmarkQueryService;
     private final ReviewKeywordRepository reviewKeywordRepository;
 
     /**
@@ -38,19 +36,16 @@ public class PlaceCommandService {
      * @throws ScrapingServerInternalError Web scraping 서버에서 에러가 발생한 경우
      * @throws PlaceAlreadyExistsException 동일한 장소 데이터가 이미 존재하는 경우
      */
-    public PlaceDto create(Long memberId, PlaceCreateRequest placeCreateRequest) {
+    public PlaceDto create(PlaceCreateRequest placeCreateRequest) {
         String kakaoPid = placeCreateRequest.getKakaoPid();
         if (placeRepository.existsByKakaoPid(kakaoPid)) {
             throw new PlaceAlreadyExistsException(kakaoPid);
         }
-
         KakaoPlaceScrapingInfo scrapingInfo = webScrapingService.getPlaceScrapingInfo(placeCreateRequest.getKakaoPid());
-
         Place savedPlace = placeRepository.save(placeCreateRequest.toDto(scrapingInfo.getHomepageUrl(), scrapingInfo.getClosingHours()).toEntity());
-        boolean placeMarkedStatus = bookmarkQueryService.isMarkedPlace(memberId, savedPlace);
 
         if (scrapingInfo.getOpeningHours() == null || scrapingInfo.getOpeningHours().isEmpty()) {
-            return PlaceDto.from(savedPlace, placeMarkedStatus);
+            return PlaceDto.from(savedPlace);
         }
 
         List<OpeningHours> openingHoursList = scrapingInfo.getOpeningHours().stream()
@@ -58,7 +53,7 @@ public class PlaceCommandService {
                 .toList();
         openingHoursRepository.saveAll(openingHoursList);
         savedPlace.getOpeningHoursList().addAll(openingHoursList);
-        return PlaceDto.from(savedPlace, placeMarkedStatus);
+        return PlaceDto.from(savedPlace);
     }
 
     /**

--- a/src/main/java/com/zelusik/eatery/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/zelusik/eatery/domain/place/service/PlaceQueryService.java
@@ -4,6 +4,7 @@ import com.zelusik.eatery.domain.bookmark.service.BookmarkQueryService;
 import com.zelusik.eatery.domain.place.constant.FilteringType;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
 import com.zelusik.eatery.domain.place.dto.PlaceFilteringKeywordDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusAndImagesDto;
 import com.zelusik.eatery.domain.place.dto.request.FindNearPlacesFilteringConditionRequest;
 import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.place.entity.Point;
@@ -73,11 +74,11 @@ public class PlaceQueryService {
      * @param placeId 조회하고자 하는 장소의 PK
      * @return 조회한 장소 dto
      */
-    public PlaceDto findDtoWithMarkedStatusAndImagesById(Long memberId, Long placeId) {
+    public PlaceWithMarkedStatusAndImagesDto findDtoWithMarkedStatusAndImagesById(Long memberId, Long placeId) {
         Place foundPlace = findById(placeId);
         boolean isMarked = bookmarkQueryService.isMarkedPlace(memberId, foundPlace);
         List<ReviewImageDto> latest3Images = reviewImageQueryService.findLatest3ByPlace(foundPlace.getId());
-        return PlaceDto.fromWithImages(foundPlace, isMarked, latest3Images);
+        return PlaceWithMarkedStatusAndImagesDto.from(foundPlace, isMarked, latest3Images);
     }
 
     /**
@@ -87,11 +88,11 @@ public class PlaceQueryService {
      * @return 조회한 장소 dto
      */
     @NonNull
-    public PlaceDto findDtoWithMarkedStatusAndImagesByKakaoPid(@NonNull Long memberId, @NonNull String kakaoPid) {
+    public PlaceWithMarkedStatusAndImagesDto findDtoWithMarkedStatusAndImagesByKakaoPid(@NonNull Long memberId, @NonNull String kakaoPid) {
         Place foundPlace = findByKakaoPid(kakaoPid);
         boolean isMarked = bookmarkQueryService.isMarkedPlace(memberId, foundPlace);
         List<ReviewImageDto> latest3ByPlace = reviewImageQueryService.findLatest3ByPlace(foundPlace.getId());
-        return PlaceDto.fromWithImages(foundPlace, isMarked, latest3ByPlace);
+        return PlaceWithMarkedStatusAndImagesDto.from(foundPlace, isMarked, latest3ByPlace);
     }
 
     /**
@@ -102,11 +103,12 @@ public class PlaceQueryService {
      * @return 조회된 장소 목록
      */
     public Slice<PlaceDto> searchDtosByKeyword(String searchKeyword, Pageable pageable) {
-        return placeRepository.searchByKeyword(searchKeyword, pageable).map(PlaceDto::fromWithoutMarkedStatusAndImages);
+        return placeRepository.searchByKeyword(searchKeyword, pageable).map(PlaceDto::from);
     }
 
     /**
      * <p>중심 좌표 기준, 가까운 순으로 장소 목록을 검색한다.
+     * <p>영업 시간 정보는 함께 조회하지 않는다.
      * <p>최대 50km 범위까지 조회한다.
      *
      * @param loginMemberId      PK of login member
@@ -115,21 +117,22 @@ public class PlaceQueryService {
      * @param pageable           paging 정보
      * @return 조회한 장소 목록
      */
-    public Page<PlaceDto> findDtosNearBy(long loginMemberId, FindNearPlacesFilteringConditionRequest filteringCondition, Point center, Pageable pageable) {
-        return placeRepository.findDtosNearBy(loginMemberId, filteringCondition, center, DISTANCE_LIMITS_FOR_FIND_NEARBY_PLACES, MAX_NUM_OF_PLACE_IMAGES, pageable);
+    public Page<PlaceWithMarkedStatusAndImagesDto> findDtosWithoutOpeningHoursNearBy(long loginMemberId, FindNearPlacesFilteringConditionRequest filteringCondition, Point center, Pageable pageable) {
+        return placeRepository.findDtosWithoutOpeningHoursNearBy(loginMemberId, filteringCondition, center, DISTANCE_LIMITS_FOR_FIND_NEARBY_PLACES, MAX_NUM_OF_PLACE_IMAGES, pageable);
     }
 
     /**
-     * 북마크에 저장한 장소 목록(Slice)을 조회합니다.
-     * 조회 시 장소와 관련된 이미지를 함께 조회합니다.
-     * 이미지를 가져오는 기준은 "해당 장소에 작성된 리뷰에 담긴 사진 중 최신순으로 최대 3개"입니다.
+     * <p>북마크에 저장한 장소 목록(Slice)을 조회한다.
+     * <p>영업 시간 정보는 함께 조회하지 않는다.
+     * <p>조회 시 장소와 관련된 이미지를 함께 조회한다.
+     * <p>이미지를 가져오는 기준은 "해당 장소에 작성된 리뷰에 담긴 사진 중 최신순으로 최대 3개"입니다.
      *
      * @param memberId 로그인 회원의 PK.
      * @param pageable paging 정보
      * @return 조회한 장소 목록
      */
-    public Page<PlaceDto> findMarkedDtos(Long memberId, FilteringType filteringType, String filteringKeyword, Pageable pageable) {
-        return placeRepository.findMarkedPlaces(memberId, filteringType, filteringKeyword, MAX_NUM_OF_PLACE_IMAGES, pageable);
+    public Page<PlaceWithMarkedStatusAndImagesDto> findMarkedDtosWithoutOpeningHours(Long memberId, FilteringType filteringType, String filteringKeyword, Pageable pageable) {
+        return placeRepository.findMarkedDtosWithoutOpeningHours(memberId, filteringType, filteringKeyword, MAX_NUM_OF_PLACE_IMAGES, pageable);
     }
 
     /**

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/api/RecommendedReviewController.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/api/RecommendedReviewController.java
@@ -1,6 +1,7 @@
 package com.zelusik.eatery.domain.recommended_review.api;
 
 import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import com.zelusik.eatery.domain.recommended_review.dto.request.BatchUpdateRecommendedReviewsRequest;
 import com.zelusik.eatery.domain.recommended_review.dto.request.SaveRecommendedReviewsRequest;
 import com.zelusik.eatery.domain.recommended_review.dto.response.BatchUpdateRecommendedReviewsResponse;
@@ -58,7 +59,7 @@ public class RecommendedReviewController {
     )
     @GetMapping(value = "/v1/members/{memberId}/recommended-reviews", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public FindRecommendedReviewsResponse findRecommendedReviewsV1_1(@PathVariable Long memberId) {
-        List<RecommendedReviewDto> recommendedReviews = recommendedReviewQueryService.findAllDtosWithPlaceMarkedStatus(memberId);
+        List<RecommendedReviewWithPlaceDto> recommendedReviews = recommendedReviewQueryService.findAllDtosWithPlaceMarkedStatus(memberId);
         return FindRecommendedReviewsResponse.from(recommendedReviews);
     }
 
@@ -70,7 +71,7 @@ public class RecommendedReviewController {
     )
     @GetMapping(value = "/v1/members/me/recommended-reviews", headers = API_MINOR_VERSION_HEADER_NAME + "=1")
     public FindMyRecommendedReviewsResponse findMyRecommendedReviewsV1_1(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        List<RecommendedReviewDto> recommendedReviews = recommendedReviewQueryService.findAllDtosWithPlaceMarkedStatus(userPrincipal.getMemberId());
+        List<RecommendedReviewWithPlaceDto> recommendedReviews = recommendedReviewQueryService.findAllDtosWithPlaceMarkedStatus(userPrincipal.getMemberId());
         return FindMyRecommendedReviewsResponse.from(recommendedReviews);
     }
 

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/RecommendedReviewDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/RecommendedReviewDto.java
@@ -1,13 +1,16 @@
 package com.zelusik.eatery.domain.recommended_review.dto;
 
 import com.zelusik.eatery.domain.recommended_review.entity.RecommendedReview;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+
+import static com.zelusik.eatery.domain.review.constant.ReviewEmbedOption.PLACE;
+import static com.zelusik.eatery.domain.review.constant.ReviewEmbedOption.WRITER;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -16,14 +19,14 @@ public class RecommendedReviewDto {
 
     private Long id;
     private Long memberId;
-    private ReviewDto review;
+    private ReviewWithPlaceMarkedStatusDto review;
     private Short ranking;
 
     public static RecommendedReviewDto fromWithoutReviewWriterAndPlace(RecommendedReview entity) {
         return new RecommendedReviewDto(
                 entity.getId(),
                 entity.getMember().getId(),
-                ReviewDto.from(entity.getReview(), List.of()),
+                ReviewWithPlaceMarkedStatusDto.fromWithoutPlace(entity.getReview(), List.of()),
                 entity.getRanking()
         );
     }
@@ -32,7 +35,7 @@ public class RecommendedReviewDto {
         return new RecommendedReviewDto(
                 entity.getId(),
                 entity.getMember().getId(),
-                ReviewDto.from(entity.getReview(), placeMarkingStatus),
+                ReviewWithPlaceMarkedStatusDto.from(entity.getReview(), List.of(WRITER, PLACE), placeMarkingStatus),
                 entity.getRanking()
         );
     }

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/RecommendedReviewWithPlaceDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/RecommendedReviewWithPlaceDto.java
@@ -1,7 +1,6 @@
 package com.zelusik.eatery.domain.recommended_review.dto;
 
 import com.zelusik.eatery.domain.recommended_review.entity.RecommendedReview;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
 import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,18 +15,18 @@ import static com.zelusik.eatery.domain.review.constant.ReviewEmbedOption.WRITER
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class RecommendedReviewDto {
+public class RecommendedReviewWithPlaceDto {
 
     private Long id;
     private Long memberId;
-    private ReviewDto review;
+    private ReviewWithPlaceMarkedStatusDto review;
     private Short ranking;
 
-    public static RecommendedReviewDto from(RecommendedReview entity) {
-        return new RecommendedReviewDto(
+    public static RecommendedReviewWithPlaceDto from(RecommendedReview entity, boolean placeMarkingStatus) {
+        return new RecommendedReviewWithPlaceDto(
                 entity.getId(),
                 entity.getMember().getId(),
-                ReviewDto.from(entity.getReview(), List.of(WRITER, PLACE)),
+                ReviewWithPlaceMarkedStatusDto.from(entity.getReview(), List.of(WRITER, PLACE), placeMarkingStatus),
                 entity.getRanking()
         );
     }

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/BatchUpdateRecommendedReviewsResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/BatchUpdateRecommendedReviewsResponse.java
@@ -16,9 +16,9 @@ public class BatchUpdateRecommendedReviewsResponse {
 
     private List<RecommendedReviewResponse> recommendedReviews;
 
-    public static BatchUpdateRecommendedReviewsResponse from(List<RecommendedReviewDto> recommendedReviewDtos) {
+    public static BatchUpdateRecommendedReviewsResponse from(List<RecommendedReviewDto> recommendedReviewWithPlaceDtos) {
         return new BatchUpdateRecommendedReviewsResponse(
-                recommendedReviewDtos.stream()
+                recommendedReviewWithPlaceDtos.stream()
                         .map(RecommendedReviewResponse::from)
                         .toList()
         );

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindMyRecommendedReviewsResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindMyRecommendedReviewsResponse.java
@@ -1,13 +1,13 @@
 package com.zelusik.eatery.domain.recommended_review.dto.response;
 
-import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
-import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
 import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.domain.review_image_menu_tag.dto.ReviewImageMenuTagDto;
+import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
+import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -67,11 +67,11 @@ public class FindMyRecommendedReviewsResponse {
             @Schema(description = "리뷰 이미지 파일 목록")
             private List<ReviewImageResponse> images;
 
-            private static ReviewResponse from(ReviewDto reviewDto) {
+            private static ReviewResponse from(ReviewWithPlaceMarkedStatusDto reviewWithPlaceMarkedStatusDto) {
                 return new ReviewResponse(
-                        reviewDto.getId(),
-                        PlaceResponse.from(reviewDto.getPlace()),
-                        reviewDto.getReviewImageDtos().stream()
+                        reviewWithPlaceMarkedStatusDto.getId(),
+                        PlaceResponse.from(reviewWithPlaceMarkedStatusDto.getPlace()),
+                        reviewWithPlaceMarkedStatusDto.getReviewImageDtos().stream()
                                 .map(ReviewImageResponse::from)
                                 .toList()
                 );
@@ -97,7 +97,7 @@ public class FindMyRecommendedReviewsResponse {
                 @Schema(description = "장소에 대한 북마크 여부", example = "false")
                 private Boolean isMarked;
 
-                private static PlaceResponse from(PlaceDto dto) {
+                private static PlaceResponse from(PlaceWithMarkedStatusDto dto) {
                     return new PlaceResponse(
                             dto.getId(),
                             dto.getName(),

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindMyRecommendedReviewsResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindMyRecommendedReviewsResponse.java
@@ -2,7 +2,7 @@ package com.zelusik.eatery.domain.recommended_review.dto.response;
 
 import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
-import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.domain.review_image_menu_tag.dto.ReviewImageMenuTagDto;
@@ -23,9 +23,9 @@ import java.util.Optional;
 public class FindMyRecommendedReviewsResponse {
     private List<RecommendedReviewResponse> recommendedReviews;
 
-    public static FindMyRecommendedReviewsResponse from(List<RecommendedReviewDto> recommendedReviewDtos) {
+    public static FindMyRecommendedReviewsResponse from(List<RecommendedReviewWithPlaceDto> recommendedReviewWithPlaceDtos) {
         return new FindMyRecommendedReviewsResponse(
-                recommendedReviewDtos.stream()
+                recommendedReviewWithPlaceDtos.stream()
                         .map(RecommendedReviewResponse::from)
                         .toList()
         );
@@ -45,11 +45,11 @@ public class FindMyRecommendedReviewsResponse {
         @Schema(description = "순위", example = "1")
         private Short ranking;
 
-        private static RecommendedReviewResponse from(RecommendedReviewDto recommendedReviewDto) {
+        private static RecommendedReviewResponse from(RecommendedReviewWithPlaceDto recommendedReviewWithPlaceDto) {
             return new RecommendedReviewResponse(
-                    recommendedReviewDto.getId(),
-                    ReviewResponse.from(recommendedReviewDto.getReview()),
-                    recommendedReviewDto.getRanking()
+                    recommendedReviewWithPlaceDto.getId(),
+                    ReviewResponse.from(recommendedReviewWithPlaceDto.getReview()),
+                    recommendedReviewWithPlaceDto.getRanking()
             );
         }
 

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindRecommendedReviewsResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindRecommendedReviewsResponse.java
@@ -1,13 +1,13 @@
 package com.zelusik.eatery.domain.recommended_review.dto.response;
 
-import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
-import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
 import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.domain.review_image_menu_tag.dto.ReviewImageMenuTagDto;
+import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
+import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -68,11 +68,11 @@ public class FindRecommendedReviewsResponse {
             @Schema(description = "리뷰 이미지 파일 목록")
             private List<ReviewImageResponse> images;
 
-            private static ReviewResponse from(ReviewDto reviewDto) {
+            private static ReviewResponse from(ReviewWithPlaceMarkedStatusDto reviewWithPlaceMarkedStatusDto) {
                 return new ReviewResponse(
-                        reviewDto.getId(),
-                        PlaceResponse.from(reviewDto.getPlace()),
-                        reviewDto.getReviewImageDtos().stream()
+                        reviewWithPlaceMarkedStatusDto.getId(),
+                        PlaceResponse.from(reviewWithPlaceMarkedStatusDto.getPlace()),
+                        reviewWithPlaceMarkedStatusDto.getReviewImageDtos().stream()
                                 .map(ReviewImageResponse::from)
                                 .toList()
                 );
@@ -98,7 +98,7 @@ public class FindRecommendedReviewsResponse {
                 @Schema(description = "장소에 대한 북마크 여부", example = "false")
                 private Boolean isMarked;
 
-                private static PlaceResponse from(PlaceDto dto) {
+                private static PlaceResponse from(PlaceWithMarkedStatusDto dto) {
                     return new PlaceResponse(
                             dto.getId(),
                             dto.getName(),

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindRecommendedReviewsResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/dto/response/FindRecommendedReviewsResponse.java
@@ -2,7 +2,7 @@ package com.zelusik.eatery.domain.recommended_review.dto.response;
 
 import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
-import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.domain.review_image_menu_tag.dto.ReviewImageMenuTagDto;
@@ -24,9 +24,9 @@ public class FindRecommendedReviewsResponse {
 
     private List<RecommendedReviewResponse> recommendedReviews;
 
-    public static FindRecommendedReviewsResponse from(List<RecommendedReviewDto> recommendedReviewDtos) {
+    public static FindRecommendedReviewsResponse from(List<RecommendedReviewWithPlaceDto> recommendedReviewWithPlaceDtos) {
         return new FindRecommendedReviewsResponse(
-                recommendedReviewDtos.stream()
+                recommendedReviewWithPlaceDtos.stream()
                         .map(RecommendedReviewResponse::from)
                         .toList()
         );
@@ -46,11 +46,11 @@ public class FindRecommendedReviewsResponse {
         @Schema(description = "순위", example = "1")
         private Short ranking;
 
-        private static RecommendedReviewResponse from(RecommendedReviewDto recommendedReviewDto) {
+        private static RecommendedReviewResponse from(RecommendedReviewWithPlaceDto recommendedReviewWithPlaceDto) {
             return new RecommendedReviewResponse(
-                    recommendedReviewDto.getId(),
-                    ReviewResponse.from(recommendedReviewDto.getReview()),
-                    recommendedReviewDto.getRanking()
+                    recommendedReviewWithPlaceDto.getId(),
+                    ReviewResponse.from(recommendedReviewWithPlaceDto.getReview()),
+                    recommendedReviewWithPlaceDto.getRanking()
             );
         }
 

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/repository/RecommendedReviewRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/repository/RecommendedReviewRepositoryQCustom.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.domain.recommended_review.repository;
 
-import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 
 import java.util.List;
 
@@ -12,5 +12,5 @@ public interface RecommendedReviewRepositoryQCustom {
      * @param memberId 추천 리뷰를 조회하고자 하는 대상 회원의 PK
      * @return 조회된 추천 리뷰들의 dto
      */
-    List<RecommendedReviewDto> findAllDtosWithPlaceMarkedStatusByMemberId(long memberId);
+    List<RecommendedReviewWithPlaceDto> findAllDtosWithPlaceMarkedStatusByMemberId(long memberId);
 }

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/repository/RecommendedReviewRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/repository/RecommendedReviewRepositoryQCustomImpl.java
@@ -4,7 +4,7 @@ import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -22,7 +22,7 @@ public class RecommendedReviewRepositoryQCustomImpl implements RecommendedReview
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<RecommendedReviewDto> findAllDtosWithPlaceMarkedStatusByMemberId(long memberId) {
+    public List<RecommendedReviewWithPlaceDto> findAllDtosWithPlaceMarkedStatusByMemberId(long memberId) {
         List<Tuple> tuples = queryFactory
                 .select(recommendedReview, subQueryForGetPlaceMarkedStatus())
                 .from(recommendedReview)
@@ -38,7 +38,7 @@ public class RecommendedReviewRepositoryQCustomImpl implements RecommendedReview
         }
 
         return tuples.stream()
-                .map(tuple -> RecommendedReviewDto.from(
+                .map(tuple -> RecommendedReviewWithPlaceDto.from(
                         Objects.requireNonNull(tuple.get(recommendedReview)),
                         Boolean.TRUE.equals(tuple.get(subQueryForGetPlaceMarkedStatus()))
                 ))

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/service/RecommendedReviewCommandService.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/service/RecommendedReviewCommandService.java
@@ -38,7 +38,7 @@ public class RecommendedReviewCommandService {
         RecommendedReview recommendedReview = RecommendedReview.of(member, review, ranking);
         recommendedReviewRepository.save(recommendedReview);
 
-        return RecommendedReviewDto.fromWithoutReviewWriterAndPlace(recommendedReview);
+        return RecommendedReviewDto.from(recommendedReview);
     }
 
     /**
@@ -64,7 +64,7 @@ public class RecommendedReviewCommandService {
         recommendedReviewRepository.saveAll(recommendedReviewsForBatchUpdate);
 
         return recommendedReviewsForBatchUpdate.stream()
-                .map(RecommendedReviewDto::fromWithoutReviewWriterAndPlace)
+                .map(RecommendedReviewDto::from)
                 .toList();
     }
 }

--- a/src/main/java/com/zelusik/eatery/domain/recommended_review/service/RecommendedReviewQueryService.java
+++ b/src/main/java/com/zelusik/eatery/domain/recommended_review/service/RecommendedReviewQueryService.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.domain.recommended_review.service;
 
-import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import com.zelusik.eatery.domain.recommended_review.repository.RecommendedReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +21,7 @@ public class RecommendedReviewQueryService {
      * @param memberId 추천 리뷰를 조회하고자 하는 대상 회원의 PK
      * @return 조회된 추천 리뷰들의 dto
      */
-    public List<RecommendedReviewDto> findAllDtosWithPlaceMarkedStatus(long memberId) {
+    public List<RecommendedReviewWithPlaceDto> findAllDtosWithPlaceMarkedStatus(long memberId) {
         return recommendedReviewRepository.findAllDtosWithPlaceMarkedStatusByMemberId(memberId);
     }
 }

--- a/src/main/java/com/zelusik/eatery/domain/review/api/ReviewController.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/api/ReviewController.java
@@ -2,7 +2,7 @@ package com.zelusik.eatery.domain.review.api;
 
 import com.zelusik.eatery.domain.review.constant.ReviewEmbedOption;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review.dto.request.ReviewCreateRequest;
 import com.zelusik.eatery.domain.review.dto.request.ReviewUpdateRequest;
 import com.zelusik.eatery.domain.review.dto.response.*;
@@ -93,8 +93,8 @@ public class ReviewController {
             ) @PathVariable Long reviewId
     ) {
         Long loginMemberId = userPrincipal.getMemberId();
-        ReviewDto reviewDto = reviewQueryService.findDtoById(loginMemberId, reviewId);
-        return FindReviewResponse.from(reviewDto, loginMemberId);
+        ReviewWithPlaceMarkedStatusDto reviewWithPlaceMarkedStatusDto = reviewQueryService.findDtoById(loginMemberId, reviewId);
+        return FindReviewResponse.from(reviewWithPlaceMarkedStatusDto, loginMemberId);
     }
 
     @Operation(
@@ -133,7 +133,7 @@ public class ReviewController {
                     example = "15"
             ) @RequestParam(required = false, defaultValue = "10") int size
     ) {
-        Slice<ReviewDto> reviewDtos = reviewQueryService.findDtos(userPrincipal.getMemberId(), writerId, placeId, embed, PageRequest.of(page, size));
+        Slice<ReviewWithPlaceMarkedStatusDto> reviewDtos = reviewQueryService.findDtos(userPrincipal.getMemberId(), writerId, placeId, embed, PageRequest.of(page, size));
         return new SliceResponse<FindReviewsResponse>().from(reviewDtos.map(FindReviewsResponse::from));
     }
 
@@ -163,7 +163,7 @@ public class ReviewController {
                     example = "15"
             ) @RequestParam(required = false, defaultValue = "15") int size
     ) {
-        Slice<ReviewDto> reviewDtos = reviewQueryService.findReviewReed(userPrincipal.getMemberId(), PageRequest.of(page, size));
+        Slice<ReviewWithPlaceMarkedStatusDto> reviewDtos = reviewQueryService.findReviewReed(userPrincipal.getMemberId(), PageRequest.of(page, size));
         return new SliceResponse<FindReviewFeedResponse>().from(reviewDtos.map(FindReviewFeedResponse::from));
     }
 
@@ -187,7 +187,7 @@ public class ReviewController {
             ) @RequestParam(required = false, defaultValue = "15") int size
     ) {
         long loginMemberId = userPrincipal.getMemberId();
-        Slice<ReviewDto> reviewDtos = reviewQueryService.findDtos(loginMemberId, loginMemberId, null, List.of(PLACE), PageRequest.of(page, size));
+        Slice<ReviewWithPlaceMarkedStatusDto> reviewDtos = reviewQueryService.findDtos(loginMemberId, loginMemberId, null, List.of(PLACE), PageRequest.of(page, size));
         return new SliceResponse<FindReviewsWrittenByMeResponse>().from(reviewDtos.map(FindReviewsWrittenByMeResponse::from));
     }
 

--- a/src/main/java/com/zelusik/eatery/domain/review/dto/ReviewWithPlaceMarkedStatusDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/dto/ReviewWithPlaceMarkedStatusDto.java
@@ -2,7 +2,6 @@ package com.zelusik.eatery.domain.review.dto;
 
 import com.zelusik.eatery.domain.member.dto.MemberDto;
 import com.zelusik.eatery.domain.member.entity.Member;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
 import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.review.constant.ReviewEmbedOption;
@@ -24,40 +23,35 @@ import static com.zelusik.eatery.domain.review.constant.ReviewEmbedOption.WRITER
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class ReviewDto {
+public class ReviewWithPlaceMarkedStatusDto {
 
     private Long id;
     private MemberDto writer;
-    private PlaceDto place;
+    private PlaceWithMarkedStatusDto place;
     private List<ReviewKeywordValue> keywords;
     private String autoCreatedContent;
     private String content;
     private List<ReviewImageDto> reviewImageDtos;
     private LocalDateTime createdAt;
 
-    public ReviewDto(PlaceDto place, List<ReviewKeywordValue> keywords, String autoCreatedContent, String content) {
+    public ReviewWithPlaceMarkedStatusDto(PlaceWithMarkedStatusDto place, List<ReviewKeywordValue> keywords, String autoCreatedContent, String content) {
         this(null, null, place, keywords, autoCreatedContent, content, null, null);
     }
 
-    public static ReviewDto from(Review entity, List<ReviewEmbedOption> embed) {
-        return new ReviewDto(
+    public static ReviewWithPlaceMarkedStatusDto fromWithoutPlace(Review entity, List<ReviewEmbedOption> embed) {
+        return from(entity, embed, null);
+    }
+
+    public static ReviewWithPlaceMarkedStatusDto from(Review entity, List<ReviewEmbedOption> embed, Boolean isMarkedPlace) {
+        return new ReviewWithPlaceMarkedStatusDto(
                 entity.getId(),
                 embed != null && embed.contains(WRITER) ? MemberDto.from(entity.getWriter()) : null,
-                embed != null && embed.contains(PLACE) ? PlaceDto.from(entity.getPlace()) : null,
+                embed != null && embed.contains(PLACE) ? PlaceWithMarkedStatusDto.from(entity.getPlace(), isMarkedPlace) : null,
                 entity.getKeywords().stream().map(ReviewKeyword::getKeyword).toList(),
                 entity.getAutoCreatedContent(),
                 entity.getContent(),
                 entity.getReviewImages().stream().map(ReviewImageDto::from).toList(),
                 entity.getCreatedAt()
-        );
-    }
-
-    public Review toEntity(Member writer, Place place) {
-        return Review.of(
-                writer,
-                place,
-                this.getAutoCreatedContent(),
-                this.getContent()
         );
     }
 }

--- a/src/main/java/com/zelusik/eatery/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.domain.review.dto.request;
 
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.review.dto.ReviewDto;
 import com.zelusik.eatery.domain.review_image.dto.request.ReviewImageCreateRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,8 +11,8 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Setter // for @ModelAttribute
 @Getter
 public class ReviewCreateRequest {
@@ -62,12 +62,8 @@ public class ReviewCreateRequest {
             images[0].menuTags[1].point.y="45.05"
             </pre>
             """)
-    @NonNull
+    @NotNull
     private List<ReviewImageCreateRequest> images;
-
-    public static ReviewCreateRequest of(long placeId, List<ReviewKeywordValue> keywords, String autoCreatedContent, String content, List<ReviewImageCreateRequest> images) {
-        return new ReviewCreateRequest(placeId, keywords, autoCreatedContent, content, images);
-    }
 
     public ReviewDto toDto(PlaceDto placeDto) {
         return new ReviewDto(

--- a/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewFeedResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewFeedResponse.java
@@ -3,7 +3,7 @@ package com.zelusik.eatery.domain.review.dto.response;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.member.dto.response.MemberResponse;
 import com.zelusik.eatery.domain.place.dto.response.PlaceCompactResponse;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -40,7 +40,7 @@ public class FindReviewFeedResponse {
     @Schema(description = "리뷰 작성 시간", example = "2023-09-01T08:01:58.253461")
     private LocalDateTime createdAt;
 
-    public static FindReviewFeedResponse from(ReviewDto dto) {
+    public static FindReviewFeedResponse from(ReviewWithPlaceMarkedStatusDto dto) {
         return new FindReviewFeedResponse(
                 dto.getId(),
                 MemberResponse.from(dto.getWriter()),

--- a/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewResponse.java
@@ -1,19 +1,20 @@
 package com.zelusik.eatery.domain.review.dto.response;
 
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.member.dto.MemberDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
-import com.zelusik.eatery.domain.member.dto.MemberDto;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.domain.review_image_menu_tag.dto.ReviewImageMenuTagDto;
+import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class FindReviewResponse {
     @Schema(description = "리뷰 이미지")
     private List<ReviewImageResponse> reviewImages;
 
-    public static FindReviewResponse from(ReviewDto dto, long loginMemberId) {
+    public static FindReviewResponse from(ReviewWithPlaceMarkedStatusDto dto, long loginMemberId) {
         return new FindReviewResponse(
                 dto.getId(),
                 WriterResponse.from(dto.getWriter(), loginMemberId),
@@ -126,9 +127,9 @@ public class FindReviewResponse {
         @Schema(description = "장소에 대한 북마크 여부", example = "false")
         private Boolean isMarked;
 
-        private static PlaceResponse from(PlaceDto dto) {
+        private static PlaceResponse from(PlaceWithMarkedStatusDto dto) {
             String snsUrl = dto.getHomepageUrl();
-            if (snsUrl != null && !snsUrl.contains("instagram")) {
+            if (!StringUtils.hasText(snsUrl) || !snsUrl.contains("instagram")) {
                 snsUrl = null;
             }
 
@@ -143,7 +144,7 @@ public class FindReviewResponse {
                     snsUrl,
                     dto.getPoint(),
                     dto.getClosingHours(),
-                    dto.getOpeningHoursDtos().stream()
+                    dto.getOpeningHours().stream()
                             .map(oh -> String.format(oh.getDayOfWeek().getDescription() + " " + oh.getOpenAt() + "-" + oh.getCloseAt()))
                             .toList(),
                     dto.getIsMarked()

--- a/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewsResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewsResponse.java
@@ -1,13 +1,13 @@
 package com.zelusik.eatery.domain.review.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.member.dto.MemberDto;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
+import com.zelusik.eatery.domain.place.entity.Address;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
+import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,7 +40,7 @@ public class FindReviewsResponse {
     @Schema(description = "리뷰에 첨부된 썸네일 이미지 url")
     private List<String> reviewThumbnailImageUrls;
 
-    public static FindReviewsResponse from(ReviewDto dto) {
+    public static FindReviewsResponse from(ReviewWithPlaceMarkedStatusDto dto) {
         return new FindReviewsResponse(
                 dto.getId(),
                 dto.getWriter() != null ? WriterResponse.from(dto.getWriter()) : null,
@@ -90,7 +90,7 @@ public class FindReviewsResponse {
         @Schema(description = "장소에 대한 북마크 여부", example = "false")
         private Boolean isMarked;
 
-        private static PlaceResponse from(PlaceDto dto) {
+        private static PlaceResponse from(PlaceWithMarkedStatusDto dto) {
             return new PlaceResponse(
                     dto.getId(),
                     dto.getName(),

--- a/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewsWrittenByMeResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/dto/response/FindReviewsWrittenByMeResponse.java
@@ -1,10 +1,10 @@
 package com.zelusik.eatery.domain.review.dto.response;
 
-import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
+import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,11 +25,11 @@ public class FindReviewsWrittenByMeResponse {
     @Schema(description = "리뷰 대표 이미지")
     private ReviewImageResponse reviewImage;
 
-    public static FindReviewsWrittenByMeResponse from(ReviewDto reviewDto) {
+    public static FindReviewsWrittenByMeResponse from(ReviewWithPlaceMarkedStatusDto reviewWithPlaceMarkedStatusDto) {
         return new FindReviewsWrittenByMeResponse(
-                reviewDto.getId(),
-                PlaceResponse.from(reviewDto.getPlace()),
-                ReviewImageResponse.from(reviewDto.getReviewImageDtos().get(0))
+                reviewWithPlaceMarkedStatusDto.getId(),
+                PlaceResponse.from(reviewWithPlaceMarkedStatusDto.getPlace()),
+                ReviewImageResponse.from(reviewWithPlaceMarkedStatusDto.getReviewImageDtos().get(0))
         );
     }
 
@@ -53,7 +53,7 @@ public class FindReviewsWrittenByMeResponse {
         @Schema(description = "장소에 대한 북마크 여부", example = "false")
         private Boolean isMarked;
 
-        private static PlaceResponse from(PlaceDto dto) {
+        private static PlaceResponse from(PlaceWithMarkedStatusDto dto) {
             return new PlaceResponse(
                     dto.getId(),
                     dto.getName(),

--- a/src/main/java/com/zelusik/eatery/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/dto/response/ReviewResponse.java
@@ -1,12 +1,12 @@
 package com.zelusik.eatery.domain.review.dto.response;
 
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
 import com.zelusik.eatery.domain.member.dto.response.MemberResponse;
 import com.zelusik.eatery.domain.place.dto.response.PlaceResponse;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.domain.review_image_menu_tag.dto.ReviewImageMenuTagDto;
+import com.zelusik.eatery.domain.review_image_menu_tag.entity.MenuTagPoint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,16 +39,16 @@ public class ReviewResponse {
     @Schema(description = "리뷰에 첨부된 이미지 파일 목록")
     private List<ReviewImageResponse> images;
 
-    public static ReviewResponse from(ReviewDto reviewDto) {
+    public static ReviewResponse from(ReviewWithPlaceMarkedStatusDto reviewWithPlaceMarkedStatusDto) {
         return new ReviewResponse(
-                reviewDto.getId(),
-                MemberResponse.from(reviewDto.getWriter()),
-                PlaceResponse.from(reviewDto.getPlace()),
-                reviewDto.getKeywords().stream()
+                reviewWithPlaceMarkedStatusDto.getId(),
+                MemberResponse.from(reviewWithPlaceMarkedStatusDto.getWriter()),
+                PlaceResponse.from(reviewWithPlaceMarkedStatusDto.getPlace()),
+                reviewWithPlaceMarkedStatusDto.getKeywords().stream()
                         .map(ReviewKeywordValue::getContent)
                         .toList(),
-                reviewDto.getContent(),
-                reviewDto.getReviewImageDtos().stream()
+                reviewWithPlaceMarkedStatusDto.getContent(),
+                reviewWithPlaceMarkedStatusDto.getReviewImageDtos().stream()
                         .map(ReviewImageResponse::from)
                         .toList()
         );

--- a/src/main/java/com/zelusik/eatery/domain/review/repository/ReviewRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/repository/ReviewRepositoryQCustom.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.domain.review.repository;
 
 import com.zelusik.eatery.domain.review.constant.ReviewEmbedOption;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -19,7 +19,7 @@ public interface ReviewRepositoryQCustom {
      * @param pageable      paging 정보
      * @return 조회된 리뷰 목록(Slice)
      */
-    Slice<ReviewDto> findDtos(Long loginMemberId, Long writerId, Long placeId, List<ReviewEmbedOption> embed, Pageable pageable);
+    Slice<ReviewWithPlaceMarkedStatusDto> findDtos(Long loginMemberId, Long writerId, Long placeId, List<ReviewEmbedOption> embed, Pageable pageable);
 
     /**
      * <p>리뷰 피드를 조회한다.
@@ -34,5 +34,5 @@ public interface ReviewRepositoryQCustom {
      * @param pageable      paging 정보
      * @return 조회된 리뷰 dtos
      */
-    Slice<ReviewDto> findReviewFeed(long loginMemberId, Pageable pageable);
+    Slice<ReviewWithPlaceMarkedStatusDto> findReviewFeed(long loginMemberId, Pageable pageable);
 }

--- a/src/main/java/com/zelusik/eatery/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/zelusik/eatery/domain/review/service/ReviewQueryService.java
@@ -2,7 +2,7 @@ package com.zelusik.eatery.domain.review.service;
 
 import com.zelusik.eatery.domain.bookmark.service.BookmarkQueryService;
 import com.zelusik.eatery.domain.review.constant.ReviewEmbedOption;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review.entity.Review;
 import com.zelusik.eatery.domain.review.exception.ReviewNotFoundException;
 import com.zelusik.eatery.domain.review.repository.ReviewRepository;
@@ -13,6 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.zelusik.eatery.domain.review.constant.ReviewEmbedOption.PLACE;
+import static com.zelusik.eatery.domain.review.constant.ReviewEmbedOption.WRITER;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -39,10 +42,10 @@ public class ReviewQueryService {
      * @param reviewId 조회하고자 하는 리뷰의 PK
      * @return 조회된 리뷰 dto
      */
-    public ReviewDto findDtoById(Long memberId, Long reviewId) {
+    public ReviewWithPlaceMarkedStatusDto findDtoById(Long memberId, Long reviewId) {
         Review review = findById(reviewId);
         boolean isMarkedPlace = bookmarkQueryService.isMarkedPlace(memberId, review.getPlace());
-        return ReviewDto.from(review, isMarkedPlace);
+        return ReviewWithPlaceMarkedStatusDto.from(review, List.of(WRITER, PLACE), isMarkedPlace);
     }
 
     /**
@@ -57,7 +60,7 @@ public class ReviewQueryService {
      * @param pageable      paging 정보
      * @return 조회된 리뷰 목록(Slice)
      */
-    public Slice<ReviewDto> findDtos(long loginMemberId, Long writerId, Long placeId, List<ReviewEmbedOption> embed, Pageable pageable) {
+    public Slice<ReviewWithPlaceMarkedStatusDto> findDtos(long loginMemberId, Long writerId, Long placeId, List<ReviewEmbedOption> embed, Pageable pageable) {
         return reviewRepository.findDtos(loginMemberId, writerId, placeId, embed, pageable);
     }
 
@@ -74,7 +77,7 @@ public class ReviewQueryService {
      * @param pageable      paging 정보
      * @return 조회된 리뷰 dtos
      */
-    public Slice<ReviewDto> findReviewReed(long loginMemberId, Pageable pageable) {
+    public Slice<ReviewWithPlaceMarkedStatusDto> findReviewReed(long loginMemberId, Pageable pageable) {
         return reviewRepository.findReviewFeed(loginMemberId, pageable);
     }
 }

--- a/src/main/java/com/zelusik/eatery/global/config/SwaggerConfig.java
+++ b/src/main/java/com/zelusik/eatery/global/config/SwaggerConfig.java
@@ -33,7 +33,7 @@ public class SwaggerConfig {
     public GroupedOpenApi groupedOpenApiVersion1() {
         return GroupedOpenApi.builder()
                 .group("v1")
-                .packagesToScan("com.zelusik.eatery.controller")
+                .packagesToScan("com.zelusik.eatery")
                 .pathsToMatch("/api/v1/**")
                 .build();
     }

--- a/src/main/java/com/zelusik/eatery/global/scraping/dto/KakaoPlaceScrapingInfo.java
+++ b/src/main/java/com/zelusik/eatery/global/scraping/dto/KakaoPlaceScrapingInfo.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.domain.place.dto;
+package com.zelusik.eatery.global.scraping.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,7 +10,7 @@ import java.util.Map;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class PlaceScrapingInfo {
+public class KakaoPlaceScrapingInfo {
 
     @Nullable
     private List<PlaceScrapingOpeningHourDto> openingHours;
@@ -21,13 +21,13 @@ public class PlaceScrapingInfo {
     @Nullable
     private String homepageUrl;
 
-    public static PlaceScrapingInfo of(List<PlaceScrapingOpeningHourDto> openingHours, String closingHours, String homepageUrl) {
-        return new PlaceScrapingInfo(openingHours, closingHours, homepageUrl);
+    public static KakaoPlaceScrapingInfo of(List<PlaceScrapingOpeningHourDto> openingHours, String closingHours, String homepageUrl) {
+        return new KakaoPlaceScrapingInfo(openingHours, closingHours, homepageUrl);
     }
 
     @SuppressWarnings("unchecked")
     // TODO: Object => List<Map> 변환 로직이 있어서 generic type casting 문제를 무시한다. 더 좋은 방법이 있다면 고려할 수 있음.
-    public static PlaceScrapingInfo from(Map<String, Object> attributes) {
+    public static KakaoPlaceScrapingInfo from(Map<String, Object> attributes) {
         List<Map<String, Object>> openingHours = (List<Map<String, Object>>) attributes.get("openingHours");
         Object closingHours = attributes.get("closingHours");
         Object homepageUrl = attributes.get("homepageUrl");

--- a/src/main/java/com/zelusik/eatery/global/scraping/dto/PlaceScrapingOpeningHourDto.java
+++ b/src/main/java/com/zelusik/eatery/global/scraping/dto/PlaceScrapingOpeningHourDto.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.domain.place.dto;
+package com.zelusik.eatery.global.scraping.dto;
 
 import com.zelusik.eatery.domain.place.constant.DayOfWeek;
 import com.zelusik.eatery.domain.opening_hours.entity.OpeningHours;

--- a/src/main/java/com/zelusik/eatery/global/scraping/service/WebScrapingService.java
+++ b/src/main/java/com/zelusik/eatery/global/scraping/service/WebScrapingService.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.global.scraping.service;
 
-import com.zelusik.eatery.domain.place.dto.PlaceScrapingInfo;
+import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
 import com.zelusik.eatery.global.scraping.exception.ScrapingServerInternalError;
 import lombok.*;
 import org.json.JSONObject;
@@ -35,7 +35,7 @@ public class WebScrapingService {
      * @return Scraping해서 읽어온 추가 정보
      * @throws ScrapingServerInternalError Web scraping 서버에서 에러가 발생한 경우
      */
-    public PlaceScrapingInfo getPlaceScrapingInfo(String kakaoPid) {
+    public KakaoPlaceScrapingInfo getPlaceScrapingInfo(String kakaoPid) {
         URI requestUri = UriComponentsBuilder.fromUriString(scrapingServerUrl + "/places/scraping")
                 .queryParam("kakaoPid", kakaoPid)
                 .encode(StandardCharsets.UTF_8)
@@ -52,7 +52,7 @@ public class WebScrapingService {
         }
 
         Map<String, Object> attributes = new JSONObject(response.getBody()).toMap();
-        return PlaceScrapingInfo.from(attributes);
+        return KakaoPlaceScrapingInfo.from(attributes);
     }
 
     /**

--- a/src/test/java/com/zelusik/eatery/integration/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/member/repository/MemberRepositoryTest.java
@@ -96,12 +96,12 @@ class MemberRepositoryTest {
 
         // then
         assertThat(result)
-                .hasFieldOrPropertyWithValue("member.id", member.getId())
-                .hasFieldOrPropertyWithValue("member.profileImageUrl", member.getProfileImageUrl())
-                .hasFieldOrPropertyWithValue("member.profileThumbnailImageUrl", member.getProfileThumbnailImageUrl())
-                .hasFieldOrPropertyWithValue("member.nickname", member.getNickname())
-                .hasFieldOrPropertyWithValue("member.gender", member.getGender())
-                .hasFieldOrPropertyWithValue("member.birthDay", member.getBirthDay())
+                .hasFieldOrPropertyWithValue("id", member.getId())
+                .hasFieldOrPropertyWithValue("profileImageUrl", member.getProfileImageUrl())
+                .hasFieldOrPropertyWithValue("profileThumbnailImageUrl", member.getProfileThumbnailImageUrl())
+                .hasFieldOrPropertyWithValue("nickname", member.getNickname())
+                .hasFieldOrPropertyWithValue("gender", member.getGender())
+                .hasFieldOrPropertyWithValue("birthDay", member.getBirthDay())
                 .hasFieldOrPropertyWithValue("numOfReviews", 3)
                 .hasFieldOrPropertyWithValue("influence", 0)
                 .hasFieldOrPropertyWithValue("numOfFollowers", 0)

--- a/src/test/java/com/zelusik/eatery/integration/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/member/repository/MemberRepositoryTest.java
@@ -16,7 +16,7 @@ import com.zelusik.eatery.domain.place.entity.Point;
 import com.zelusik.eatery.domain.review.entity.Review;
 import com.zelusik.eatery.domain.review_image.entity.ReviewImage;
 import com.zelusik.eatery.domain.review_keyword.entity.ReviewKeyword;
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import com.zelusik.eatery.domain.member.exception.MemberIdNotFoundException;
 import com.zelusik.eatery.domain.member.repository.MemberRepository;
 import com.zelusik.eatery.domain.place.repository.PlaceRepository;
@@ -92,16 +92,16 @@ class MemberRepositoryTest {
         review3.getKeywords().add(reviewKeywordRepository.save(createNewReviewKeyword(review3, ReviewKeywordValue.NOISY)));
 
         // when
-        MemberProfileInfoDto result = sut.getMemberProfileInfoById(member.getId());
+        MemberWithProfileInfoDto result = sut.getMemberProfileInfoById(member.getId());
 
         // then
         assertThat(result)
-                .hasFieldOrPropertyWithValue("id", member.getId())
-                .hasFieldOrPropertyWithValue("profileImageUrl", member.getProfileImageUrl())
-                .hasFieldOrPropertyWithValue("profileThumbnailImageUrl", member.getProfileThumbnailImageUrl())
-                .hasFieldOrPropertyWithValue("nickname", member.getNickname())
-                .hasFieldOrPropertyWithValue("gender", member.getGender())
-                .hasFieldOrPropertyWithValue("birthDay", member.getBirthDay())
+                .hasFieldOrPropertyWithValue("member.id", member.getId())
+                .hasFieldOrPropertyWithValue("member.profileImageUrl", member.getProfileImageUrl())
+                .hasFieldOrPropertyWithValue("member.profileThumbnailImageUrl", member.getProfileThumbnailImageUrl())
+                .hasFieldOrPropertyWithValue("member.nickname", member.getNickname())
+                .hasFieldOrPropertyWithValue("member.gender", member.getGender())
+                .hasFieldOrPropertyWithValue("member.birthDay", member.getBirthDay())
                 .hasFieldOrPropertyWithValue("numOfReviews", 3)
                 .hasFieldOrPropertyWithValue("influence", 0)
                 .hasFieldOrPropertyWithValue("numOfFollowers", 0)

--- a/src/test/java/com/zelusik/eatery/integration/domain/place/repository/PlaceRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/place/repository/PlaceRepositoryTest.java
@@ -1,28 +1,29 @@
 package com.zelusik.eatery.integration.domain.place.repository;
 
-import com.zelusik.eatery.global.config.JpaConfig;
-import com.zelusik.eatery.global.config.QuerydslConfig;
+import com.zelusik.eatery.domain.bookmark.entity.Bookmark;
+import com.zelusik.eatery.domain.bookmark.repository.BookmarkRepository;
 import com.zelusik.eatery.domain.member.constant.Gender;
 import com.zelusik.eatery.domain.member.constant.LoginType;
 import com.zelusik.eatery.domain.member.constant.RoleType;
+import com.zelusik.eatery.domain.member.entity.Member;
+import com.zelusik.eatery.domain.member.repository.MemberRepository;
+import com.zelusik.eatery.domain.opening_hours.entity.OpeningHours;
+import com.zelusik.eatery.domain.opening_hours.repository.OpeningHoursRepository;
 import com.zelusik.eatery.domain.place.constant.DayOfWeek;
 import com.zelusik.eatery.domain.place.constant.FilteringType;
 import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.bookmark.entity.Bookmark;
-import com.zelusik.eatery.domain.member.entity.Member;
-import com.zelusik.eatery.domain.opening_hours.entity.OpeningHours;
+import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.place.dto.PlaceFilteringKeywordDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusAndImagesDto;
+import com.zelusik.eatery.domain.place.dto.request.FindNearPlacesFilteringConditionRequest;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.domain.place.dto.PlaceFilteringKeywordDto;
-import com.zelusik.eatery.domain.place.dto.request.FindNearPlacesFilteringConditionRequest;
-import com.zelusik.eatery.domain.bookmark.repository.BookmarkRepository;
-import com.zelusik.eatery.domain.member.repository.MemberRepository;
-import com.zelusik.eatery.domain.opening_hours.repository.OpeningHoursRepository;
 import com.zelusik.eatery.domain.place.repository.PlaceRepository;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.global.config.JpaConfig;
+import com.zelusik.eatery.global.config.QuerydslConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,8 +41,8 @@ import java.util.Set;
 
 import static com.zelusik.eatery.domain.place.constant.DayOfWeek.MON;
 import static com.zelusik.eatery.domain.place.constant.DayOfWeek.WED;
-import static com.zelusik.eatery.domain.review.constant.ReviewKeywordValue.*;
 import static com.zelusik.eatery.domain.place.service.PlaceQueryService.MAX_NUM_OF_PLACE_IMAGES;
+import static com.zelusik.eatery.domain.review.constant.ReviewKeywordValue.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -86,7 +87,7 @@ class PlaceRepositoryTest {
         }
 
         // when
-        Slice<PlaceDto> places = sut.findDtosNearBy(memberId, filteringCondition, center, 1100, MAX_NUM_OF_PLACE_IMAGES, PageRequest.of(0, 30));
+        Slice<PlaceWithMarkedStatusAndImagesDto> places = sut.findDtosWithoutOpeningHoursNearBy(memberId, filteringCondition, center, 1100, MAX_NUM_OF_PLACE_IMAGES, PageRequest.of(0, 30));
 
         // then
         assertThat(places.getSize()).isEqualTo(30);
@@ -120,11 +121,11 @@ class PlaceRepositoryTest {
 
         // when
         Pageable pageable = Pageable.ofSize(30);
-        Slice<PlaceDto> placesLimit50 = sut.findDtosNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, null, null, false), pos, 50, MAX_NUM_OF_PLACE_IMAGES, pageable);
-        Slice<PlaceDto> placesLimit1100 = sut.findDtosNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, null, null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
-        Slice<PlaceDto> placesLimit1100DaysMon = sut.findDtosNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, List.of(MON), null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
-        Slice<PlaceDto> placesLimit1100DaysWed = sut.findDtosNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, List.of(WED), null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
-        Slice<PlaceDto> placesLimit1100DaysMonAndWed = sut.findDtosNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, List.of(MON, WED), null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
+        Slice<PlaceWithMarkedStatusAndImagesDto> placesLimit50 = sut.findDtosWithoutOpeningHoursNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, null, null, false), pos, 50, MAX_NUM_OF_PLACE_IMAGES, pageable);
+        Slice<PlaceWithMarkedStatusAndImagesDto> placesLimit1100 = sut.findDtosWithoutOpeningHoursNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, null, null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
+        Slice<PlaceWithMarkedStatusAndImagesDto> placesLimit1100DaysMon = sut.findDtosWithoutOpeningHoursNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, List.of(MON), null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
+        Slice<PlaceWithMarkedStatusAndImagesDto> placesLimit1100DaysWed = sut.findDtosWithoutOpeningHoursNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, List.of(WED), null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
+        Slice<PlaceWithMarkedStatusAndImagesDto> placesLimit1100DaysMonAndWed = sut.findDtosWithoutOpeningHoursNearBy(memberId, new FindNearPlacesFilteringConditionRequest(null, List.of(MON, WED), null, false), pos, 1100, MAX_NUM_OF_PLACE_IMAGES, pageable);
 
         // then
         assertThat(placesLimit50.getNumberOfElements()).isEqualTo(2);

--- a/src/test/java/com/zelusik/eatery/integration/domain/recommended_review/repository/RecommendedReviewRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/recommended_review/repository/RecommendedReviewRepositoryTest.java
@@ -16,7 +16,7 @@ import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
 import com.zelusik.eatery.domain.review.entity.Review;
 import com.zelusik.eatery.domain.review_keyword.entity.ReviewKeyword;
-import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import com.zelusik.eatery.domain.bookmark.repository.BookmarkRepository;
 import com.zelusik.eatery.domain.member.repository.MemberRepository;
 import com.zelusik.eatery.domain.place.repository.PlaceRepository;
@@ -78,13 +78,13 @@ class RecommendedReviewRepositoryTest {
         ));
 
         // when
-        List<RecommendedReviewDto> result = sut.findAllDtosWithPlaceMarkedStatusByMemberId(member.getId());
+        List<RecommendedReviewWithPlaceDto> result = sut.findAllDtosWithPlaceMarkedStatusByMemberId(member.getId());
 
         // then
         assertThat(result).hasSize(savedRecommendedReviews.size());
         for (int i = 0; i < savedRecommendedReviews.size(); i++) {
             RecommendedReview expectedResult = savedRecommendedReviews.get(i);
-            RecommendedReviewDto actualResult = result.get(i);
+            RecommendedReviewWithPlaceDto actualResult = result.get(i);
             assertThat(actualResult)
                     .hasFieldOrPropertyWithValue("id", expectedResult.getId())
                     .hasFieldOrPropertyWithValue("memberId", expectedResult.getMember().getId())
@@ -102,7 +102,7 @@ class RecommendedReviewRepositoryTest {
         // given
 
         // when
-        List<RecommendedReviewDto> result = sut.findAllDtosWithPlaceMarkedStatusByMemberId(1L);
+        List<RecommendedReviewWithPlaceDto> result = sut.findAllDtosWithPlaceMarkedStatusByMemberId(1L);
 
         // then
         assertThat(result).hasSize(0);

--- a/src/test/java/com/zelusik/eatery/integration/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/review/repository/ReviewRepositoryTest.java
@@ -15,7 +15,7 @@ import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
 import com.zelusik.eatery.domain.review.entity.Review;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.bookmark.repository.BookmarkRepository;
 import com.zelusik.eatery.domain.favorite_food_category.repository.FavoriteFoodCategoryRepository;
 import com.zelusik.eatery.domain.member.repository.MemberRepository;
@@ -73,12 +73,12 @@ class ReviewRepositoryTest {
         bookmarkRepository.save(createNewBookmark(member, place));
 
         // when
-        Slice<ReviewDto> results = sut.findDtos(member.getId(), null, null, List.of(WRITER, PLACE), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findDtos(member.getId(), null, null, List.of(WRITER, PLACE), Pageable.ofSize(10));
 
         // then
         assertThat(results.getNumberOfElements()).isEqualTo(3);
         assertThat(results.getContent()).hasSize(3);
-        for (ReviewDto result : results) {
+        for (ReviewWithPlaceMarkedStatusDto result : results) {
             assertThat(result)
                     .hasFieldOrProperty("writer").isNotNull()
                     .hasFieldOrProperty("place").isNotNull()
@@ -104,12 +104,12 @@ class ReviewRepositoryTest {
         ));
 
         // when
-        Slice<ReviewDto> results = sut.findDtos(member1.getId(), member1.getId(), null, List.of(WRITER, PLACE), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findDtos(member1.getId(), member1.getId(), null, List.of(WRITER, PLACE), Pageable.ofSize(10));
 
         // then
         assertThat(results.getNumberOfElements()).isEqualTo(2);
         assertThat(results.getContent()).hasSize(2);
-        for (ReviewDto result : results) {
+        for (ReviewWithPlaceMarkedStatusDto result : results) {
             assertThat(result)
                     .hasFieldOrProperty("writer").isNotNull()
                     .hasFieldOrPropertyWithValue("writer.socialUid", member1.getSocialUid())
@@ -136,12 +136,12 @@ class ReviewRepositoryTest {
         ));
 
         // when
-        Slice<ReviewDto> results = sut.findDtos(member.getId(), null, place1.getId(), List.of(WRITER, PLACE), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findDtos(member.getId(), null, place1.getId(), List.of(WRITER, PLACE), Pageable.ofSize(10));
 
         // then
         assertThat(results.getNumberOfElements()).isEqualTo(1);
         assertThat(results.getContent()).hasSize(1);
-        for (ReviewDto result : results) {
+        for (ReviewWithPlaceMarkedStatusDto result : results) {
             assertThat(result)
                     .hasFieldOrProperty("writer").isNotNull()
                     .hasFieldOrPropertyWithValue("writer.socialUid", member.getSocialUid())
@@ -171,12 +171,12 @@ class ReviewRepositoryTest {
         ));
 
         // when
-        Slice<ReviewDto> results = sut.findDtos(member1.getId(), member1.getId(), place2.getId(), List.of(WRITER, PLACE), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findDtos(member1.getId(), member1.getId(), place2.getId(), List.of(WRITER, PLACE), Pageable.ofSize(10));
 
         // then
         assertThat(results.getNumberOfElements()).isEqualTo(2);
         assertThat(results.getContent()).hasSize(2);
-        for (ReviewDto result : results) {
+        for (ReviewWithPlaceMarkedStatusDto result : results) {
             assertThat(result)
                     .hasFieldOrProperty("writer").isNotNull()
                     .hasFieldOrPropertyWithValue("writer.socialUid", member1.getSocialUid())
@@ -202,12 +202,12 @@ class ReviewRepositoryTest {
         ));
 
         // when
-        Slice<ReviewDto> results = sut.findDtos(member.getId(), null, null, List.of(), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findDtos(member.getId(), null, null, List.of(), Pageable.ofSize(10));
 
         // then
         assertThat(results.getNumberOfElements()).isEqualTo(3);
         assertThat(results.getContent()).hasSize(3);
-        for (ReviewDto result : results) {
+        for (ReviewWithPlaceMarkedStatusDto result : results) {
             assertThat(result)
                     .hasFieldOrPropertyWithValue("writer", null)
                     .hasFieldOrPropertyWithValue("place", null)
@@ -231,12 +231,12 @@ class ReviewRepositoryTest {
         ));
 
         // when
-        Slice<ReviewDto> results = sut.findDtos(member.getId(), null, null, List.of(WRITER), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findDtos(member.getId(), null, null, List.of(WRITER), Pageable.ofSize(10));
 
         // then
         assertThat(results.getNumberOfElements()).isEqualTo(3);
         assertThat(results.getContent()).hasSize(3);
-        for (ReviewDto result : results) {
+        for (ReviewWithPlaceMarkedStatusDto result : results) {
             assertThat(result)
                     .hasFieldOrProperty("writer").isNotNull()
                     .hasFieldOrPropertyWithValue("place", null)
@@ -260,12 +260,12 @@ class ReviewRepositoryTest {
         ));
 
         // when
-        Slice<ReviewDto> results = sut.findDtos(member.getId(), null, null, List.of(PLACE), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findDtos(member.getId(), null, null, List.of(PLACE), Pageable.ofSize(10));
 
         // then
         assertThat(results.getNumberOfElements()).isEqualTo(3);
         assertThat(results.getContent()).hasSize(3);
-        for (ReviewDto result : results) {
+        for (ReviewWithPlaceMarkedStatusDto result : results) {
             assertThat(result)
                     .hasFieldOrPropertyWithValue("writer", null)
                     .hasFieldOrProperty("place").isNotNull()
@@ -295,13 +295,13 @@ class ReviewRepositoryTest {
         ));
 
         // when
-        Slice<ReviewDto> results = sut.findReviewFeed(member1.getId(), Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> results = sut.findReviewFeed(member1.getId(), Pageable.ofSize(10));
 
         // then
         assertThat(results).hasSize(3);  // 내가 작성한 리뷰는 조회되지 않음
-        List<ReviewDto> content = results.getContent();
+        List<ReviewWithPlaceMarkedStatusDto> content = results.getContent();
         for (int i = 0; i < results.getNumberOfElements(); i++) {
-            ReviewDto result = content.get(i);
+            ReviewWithPlaceMarkedStatusDto result = content.get(i);
             assertThat(result).hasFieldOrPropertyWithValue("writer.id", member2.getId());
             // 리뷰를 작성한 장소의 카테고리가 내가 선호하는 음식 카테고리에 해당되는 리뷰의 우선순위가 더 높다
             if (i < results.getNumberOfElements() - 1

--- a/src/test/java/com/zelusik/eatery/integration/global/scraping/service/WebScrapingServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/global/scraping/service/WebScrapingServiceTest.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.integration.global.scraping.service;
 
-import com.zelusik.eatery.domain.place.dto.PlaceScrapingInfo;
+import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
 import com.zelusik.eatery.global.scraping.service.WebScrapingService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +28,7 @@ class WebScrapingServiceTest {
         String kakaoPid = "1879186093"; // 경기도 수원시 일호선의 kakao place id
 
         // when
-        PlaceScrapingInfo response = sut.getPlaceScrapingInfo(kakaoPid);
+        KakaoPlaceScrapingInfo response = sut.getPlaceScrapingInfo(kakaoPid);
 
         // then
         assertThat(response).isNotNull();

--- a/src/test/java/com/zelusik/eatery/unit/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/member/api/MemberControllerTest.java
@@ -7,7 +7,7 @@ import com.zelusik.eatery.domain.member.constant.Gender;
 import com.zelusik.eatery.domain.member.constant.LoginType;
 import com.zelusik.eatery.domain.member.constant.RoleType;
 import com.zelusik.eatery.domain.member.dto.MemberDto;
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import com.zelusik.eatery.domain.member.dto.request.MemberUpdateRequest;
 import com.zelusik.eatery.domain.member.service.MemberCommandService;
 import com.zelusik.eatery.domain.member.service.MemberQueryService;
@@ -100,7 +100,7 @@ class MemberControllerTest {
         String mostVisitedLocation = "연남동";
         ReviewKeywordValue mostTaggedReviewKeyword = ReviewKeywordValue.FRESH;
         FoodCategoryValue mostEatenFoodCategory = FoodCategoryValue.KOREAN;
-        MemberProfileInfoDto expectedResult = createMemberProfileInfoDto(memberId, numOfReviews, mostVisitedLocation, mostTaggedReviewKeyword, mostEatenFoodCategory);
+        MemberWithProfileInfoDto expectedResult = createMemberWithProfileInfoDto(memberId, numOfReviews, mostVisitedLocation, mostTaggedReviewKeyword, mostEatenFoodCategory);
         given(memberQueryService.getMemberProfileInfoById(memberId)).willReturn(expectedResult);
 
         // when & then
@@ -110,12 +110,12 @@ class MemberControllerTest {
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(expectedResult.getId()))
-                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getProfileImageUrl()))
-                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getProfileThumbnailImageUrl()))
-                .andExpect(jsonPath("$.nickname").value(expectedResult.getNickname()))
-                .andExpect(jsonPath("$.gender").value(expectedResult.getGender().getDescription()))
-                .andExpect(jsonPath("$.birthDay").value(expectedResult.getBirthDay().toString()))
+                .andExpect(jsonPath("$.id").value(expectedResult.getMember().getId()))
+                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getMember().getProfileImageUrl()))
+                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getMember().getProfileThumbnailImageUrl()))
+                .andExpect(jsonPath("$.nickname").value(expectedResult.getMember().getNickname()))
+                .andExpect(jsonPath("$.gender").value(expectedResult.getMember().getGender().getDescription()))
+                .andExpect(jsonPath("$.birthDay").value(expectedResult.getMember().getBirthDay().toString()))
                 .andExpect(jsonPath("$.numOfReviews").value(numOfReviews))
                 .andExpect(jsonPath("$.influence").value(0))
                 .andExpect(jsonPath("$.numOfFollowers").value(0))
@@ -135,7 +135,7 @@ class MemberControllerTest {
         String mostVisitedLocation = "연남동";
         ReviewKeywordValue mostTaggedReviewKeyword = ReviewKeywordValue.FRESH;
         FoodCategoryValue mostEatenFoodCategory = FoodCategoryValue.KOREAN;
-        MemberProfileInfoDto expectedResult = createMemberProfileInfoDto(memberId, numOfReviews, mostVisitedLocation, mostTaggedReviewKeyword, mostEatenFoodCategory);
+        MemberWithProfileInfoDto expectedResult = createMemberWithProfileInfoDto(memberId, numOfReviews, mostVisitedLocation, mostTaggedReviewKeyword, mostEatenFoodCategory);
         given(memberQueryService.getMemberProfileInfoById(memberId)).willReturn(expectedResult);
 
         // when & then
@@ -145,11 +145,11 @@ class MemberControllerTest {
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(expectedResult.getId()))
+                .andExpect(jsonPath("$.id").value(expectedResult.getMember().getId()))
                 .andExpect(jsonPath("$.isEqualLoginMember").value(loginMemberId == memberId))
-                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getProfileImageUrl()))
-                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getProfileThumbnailImageUrl()))
-                .andExpect(jsonPath("$.nickname").value(expectedResult.getNickname()))
+                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getMember().getProfileImageUrl()))
+                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getMember().getProfileThumbnailImageUrl()))
+                .andExpect(jsonPath("$.nickname").value(expectedResult.getMember().getNickname()))
                 .andExpect(jsonPath("$.numOfReviews").value(numOfReviews))
                 .andExpect(jsonPath("$.influence").value(0))
                 .andExpect(jsonPath("$.numOfFollowers").value(0))
@@ -280,14 +280,9 @@ class MemberControllerTest {
     }
 
     @NonNull
-    private MemberProfileInfoDto createMemberProfileInfoDto(long memberId, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
-        return new MemberProfileInfoDto(
-                memberId,
-                EateryConstants.defaultProfileImageUrl,
-                EateryConstants.defaultProfileThumbnailImageUrl,
-                "test",
-                Gender.MALE,
-                LocalDate.of(2000, 1, 1),
+    private MemberWithProfileInfoDto createMemberWithProfileInfoDto(long memberId, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
+        return new MemberWithProfileInfoDto(
+                createMemberDto(memberId),
                 numOfReviews,
                 0,
                 0,

--- a/src/test/java/com/zelusik/eatery/unit/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/member/api/MemberControllerTest.java
@@ -110,12 +110,12 @@ class MemberControllerTest {
                                 .with(user(createTestUserDetails(memberId)))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(expectedResult.getMember().getId()))
-                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getMember().getProfileImageUrl()))
-                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getMember().getProfileThumbnailImageUrl()))
-                .andExpect(jsonPath("$.nickname").value(expectedResult.getMember().getNickname()))
-                .andExpect(jsonPath("$.gender").value(expectedResult.getMember().getGender().getDescription()))
-                .andExpect(jsonPath("$.birthDay").value(expectedResult.getMember().getBirthDay().toString()))
+                .andExpect(jsonPath("$.id").value(expectedResult.getId()))
+                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getProfileImageUrl()))
+                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getProfileThumbnailImageUrl()))
+                .andExpect(jsonPath("$.nickname").value(expectedResult.getNickname()))
+                .andExpect(jsonPath("$.gender").value(expectedResult.getGender().getDescription()))
+                .andExpect(jsonPath("$.birthDay").value(expectedResult.getBirthDay().toString()))
                 .andExpect(jsonPath("$.numOfReviews").value(numOfReviews))
                 .andExpect(jsonPath("$.influence").value(0))
                 .andExpect(jsonPath("$.numOfFollowers").value(0))
@@ -145,11 +145,11 @@ class MemberControllerTest {
                                 .with(user(createTestUserDetails(loginMemberId)))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(expectedResult.getMember().getId()))
+                .andExpect(jsonPath("$.id").value(expectedResult.getId()))
                 .andExpect(jsonPath("$.isEqualLoginMember").value(loginMemberId == memberId))
-                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getMember().getProfileImageUrl()))
-                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getMember().getProfileThumbnailImageUrl()))
-                .andExpect(jsonPath("$.nickname").value(expectedResult.getMember().getNickname()))
+                .andExpect(jsonPath("$.profileImage.imageUrl").value(expectedResult.getProfileImageUrl()))
+                .andExpect(jsonPath("$.profileImage.thumbnailImageUrl").value(expectedResult.getProfileThumbnailImageUrl()))
+                .andExpect(jsonPath("$.nickname").value(expectedResult.getNickname()))
                 .andExpect(jsonPath("$.numOfReviews").value(numOfReviews))
                 .andExpect(jsonPath("$.influence").value(0))
                 .andExpect(jsonPath("$.numOfFollowers").value(0))
@@ -282,11 +282,20 @@ class MemberControllerTest {
     @NonNull
     private MemberWithProfileInfoDto createMemberWithProfileInfoDto(long memberId, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
         return new MemberWithProfileInfoDto(
-                createMemberDto(memberId),
+                memberId,
+                EateryConstants.defaultProfileImageUrl,
+                EateryConstants.defaultProfileThumbnailImageUrl,
+                "1234567890",
+                LoginType.KAKAO,
+                Set.of(RoleType.USER),
+                "test@test.com",
+                "test",
+                LocalDate.of(2000, 1, 1),
+                20,
+                Gender.MALE,
+                List.of(FoodCategoryValue.KOREAN),
+                null,
                 numOfReviews,
-                0,
-                0,
-                0,
                 mostVisitedLocation,
                 mostTaggedReviewKeyword,
                 mostEatenFoodCategory

--- a/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberQueryServiceTest.java
@@ -146,7 +146,7 @@ class MemberQueryServiceTest {
         then(memberRepository).should().getMemberProfileInfoById(memberId);
         then(memberRepository).shouldHaveNoMoreInteractions();
         assertThat(actualResult)
-                .hasFieldOrPropertyWithValue("member.id", memberId)
+                .hasFieldOrPropertyWithValue("id", memberId)
                 .hasFieldOrPropertyWithValue("numOfReviews", numOfReviews)
                 .hasFieldOrPropertyWithValue("influence", 0)
                 .hasFieldOrPropertyWithValue("numOfFollowers", 0)
@@ -181,7 +181,7 @@ class MemberQueryServiceTest {
 
     @NonNull
     private MemberWithProfileInfoDto createMemberProfileInfoDto(long memberId, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
-        return MemberWithProfileInfoDto.of(
+        return MemberWithProfileInfoDto.from(
                 createMember(memberId),
                 numOfReviews,
                 mostVisitedLocation,

--- a/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberQueryServiceTest.java
@@ -4,7 +4,7 @@ import com.zelusik.eatery.domain.member.constant.Gender;
 import com.zelusik.eatery.domain.member.constant.LoginType;
 import com.zelusik.eatery.domain.member.constant.RoleType;
 import com.zelusik.eatery.domain.member.dto.MemberDto;
-import com.zelusik.eatery.domain.member.dto.MemberProfileInfoDto;
+import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
 import com.zelusik.eatery.domain.member.entity.Member;
 import com.zelusik.eatery.domain.member.exception.MemberIdNotFoundException;
 import com.zelusik.eatery.domain.member.repository.MemberRepository;
@@ -136,17 +136,17 @@ class MemberQueryServiceTest {
         String mostVisitedLocation = "연남동";
         ReviewKeywordValue mostTaggedReviewKeyword = ReviewKeywordValue.FRESH;
         FoodCategoryValue mostEatenFoodCategory = FoodCategoryValue.KOREAN;
-        MemberProfileInfoDto expectedResult = createMemberProfileInfoDto(memberId, numOfReviews, mostVisitedLocation, mostTaggedReviewKeyword, mostEatenFoodCategory);
+        MemberWithProfileInfoDto expectedResult = createMemberProfileInfoDto(memberId, numOfReviews, mostVisitedLocation, mostTaggedReviewKeyword, mostEatenFoodCategory);
         given(memberRepository.getMemberProfileInfoById(memberId)).willReturn(expectedResult);
 
         // when
-        MemberProfileInfoDto actualResult = sut.getMemberProfileInfoById(memberId);
+        MemberWithProfileInfoDto actualResult = sut.getMemberProfileInfoById(memberId);
 
         // then
         then(memberRepository).should().getMemberProfileInfoById(memberId);
         then(memberRepository).shouldHaveNoMoreInteractions();
         assertThat(actualResult)
-                .hasFieldOrPropertyWithValue("id", memberId)
+                .hasFieldOrPropertyWithValue("member.id", memberId)
                 .hasFieldOrPropertyWithValue("numOfReviews", numOfReviews)
                 .hasFieldOrPropertyWithValue("influence", 0)
                 .hasFieldOrPropertyWithValue("numOfFollowers", 0)
@@ -180,8 +180,8 @@ class MemberQueryServiceTest {
     }
 
     @NonNull
-    private MemberProfileInfoDto createMemberProfileInfoDto(long memberId, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
-        return MemberProfileInfoDto.of(
+    private MemberWithProfileInfoDto createMemberProfileInfoDto(long memberId, int numOfReviews, String mostVisitedLocation, ReviewKeywordValue mostTaggedReviewKeyword, FoodCategoryValue mostEatenFoodCategory) {
+        return MemberWithProfileInfoDto.of(
                 createMember(memberId),
                 numOfReviews,
                 mostVisitedLocation,

--- a/src/test/java/com/zelusik/eatery/unit/domain/place/service/PlaceCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/place/service/PlaceCommandServiceTest.java
@@ -6,8 +6,8 @@ import com.zelusik.eatery.domain.opening_hours.repository.OpeningHoursRepository
 import com.zelusik.eatery.domain.place.constant.DayOfWeek;
 import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.domain.place.dto.PlaceScrapingInfo;
-import com.zelusik.eatery.domain.place.dto.PlaceScrapingOpeningHourDto;
+import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
+import com.zelusik.eatery.global.scraping.dto.PlaceScrapingOpeningHourDto;
 import com.zelusik.eatery.domain.place.dto.request.PlaceCreateRequest;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Place;
@@ -70,11 +70,11 @@ class PlaceCommandServiceTest {
         );
         String closingHours = "토요일\n일요일";
         String homepageUrl = "https://homepage.url";
-        PlaceScrapingInfo placeScrapingInfo = PlaceScrapingInfo.of(openingHourDtos, closingHours, homepageUrl);
+        KakaoPlaceScrapingInfo kakaoPlaceScrapingInfo = KakaoPlaceScrapingInfo.of(openingHourDtos, closingHours, homepageUrl);
         PlaceCreateRequest placeCreateRequest = createPlaceRequest();
         Place expectedResult = createPlace(placeId, placeCreateRequest.getKakaoPid(), homepageUrl, closingHours);
         given(placeRepository.existsByKakaoPid(placeCreateRequest.getKakaoPid())).willReturn(false);
-        given(webScrapingService.getPlaceScrapingInfo(placeCreateRequest.getKakaoPid())).willReturn(placeScrapingInfo);
+        given(webScrapingService.getPlaceScrapingInfo(placeCreateRequest.getKakaoPid())).willReturn(kakaoPlaceScrapingInfo);
         given(placeRepository.save(any(Place.class))).willReturn(expectedResult);
         given(openingHoursRepository.saveAll(ArgumentMatchers.<List<OpeningHours>>any())).willReturn(List.of());
         given(bookmarkQueryService.isMarkedPlace(memberId, expectedResult)).willReturn(false);

--- a/src/test/java/com/zelusik/eatery/unit/domain/place/service/PlaceCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/place/service/PlaceCommandServiceTest.java
@@ -1,13 +1,10 @@
 package com.zelusik.eatery.unit.domain.place.service;
 
-import com.zelusik.eatery.domain.bookmark.service.BookmarkQueryService;
 import com.zelusik.eatery.domain.opening_hours.entity.OpeningHours;
 import com.zelusik.eatery.domain.opening_hours.repository.OpeningHoursRepository;
 import com.zelusik.eatery.domain.place.constant.DayOfWeek;
 import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
-import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
-import com.zelusik.eatery.global.scraping.dto.PlaceScrapingOpeningHourDto;
 import com.zelusik.eatery.domain.place.dto.request.PlaceCreateRequest;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Place;
@@ -18,6 +15,8 @@ import com.zelusik.eatery.domain.place.repository.PlaceRepository;
 import com.zelusik.eatery.domain.place.service.PlaceCommandService;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
 import com.zelusik.eatery.domain.review_keyword.repository.ReviewKeywordRepository;
+import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
+import com.zelusik.eatery.global.scraping.dto.PlaceScrapingOpeningHourDto;
 import com.zelusik.eatery.global.scraping.service.WebScrapingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,16 +50,13 @@ class PlaceCommandServiceTest {
     @Mock
     private OpeningHoursRepository openingHoursRepository;
     @Mock
-    private BookmarkQueryService bookmarkQueryService;
-    @Mock
     private ReviewKeywordRepository reviewKeywordRepository;
 
     @DisplayName("영업시간이 포함된 장소 정보가 주어지면 장소를 생성 및 저장하고 저장된 장소를 반환한다.")
     @Test
     void givenPlaceRequestInfoWithOpeningHours_whenCreatePlace_thenReturnSavedPlace() {
         // given
-        long memberId = 1L;
-        long placeId = 2L;
+        long placeId = 1L;
         List<PlaceScrapingOpeningHourDto> openingHourDtos = List.of(
                 PlaceScrapingOpeningHourDto.of(DayOfWeek.MON, LocalTime.of(12, 0), LocalTime.of(22, 0)),
                 PlaceScrapingOpeningHourDto.of(DayOfWeek.TUE, LocalTime.of(12, 0), LocalTime.of(22, 0)),
@@ -77,17 +73,15 @@ class PlaceCommandServiceTest {
         given(webScrapingService.getPlaceScrapingInfo(placeCreateRequest.getKakaoPid())).willReturn(kakaoPlaceScrapingInfo);
         given(placeRepository.save(any(Place.class))).willReturn(expectedResult);
         given(openingHoursRepository.saveAll(ArgumentMatchers.<List<OpeningHours>>any())).willReturn(List.of());
-        given(bookmarkQueryService.isMarkedPlace(memberId, expectedResult)).willReturn(false);
 
         // when
-        PlaceDto actualResult = sut.create(memberId, placeCreateRequest);
+        PlaceDto actualResult = sut.create(placeCreateRequest);
 
         // then
         then(placeRepository).should().existsByKakaoPid(placeCreateRequest.getKakaoPid());
         then(webScrapingService).should().getPlaceScrapingInfo(placeCreateRequest.getKakaoPid());
         then(placeRepository).should().save(any(Place.class));
         then(openingHoursRepository).should().saveAll(ArgumentMatchers.<List<OpeningHours>>any());
-        then(bookmarkQueryService).should().isMarkedPlace(memberId, expectedResult);
         verifyEveryMocksShouldHaveNoMoreInteractions();
         assertThat(actualResult.getKakaoPid()).isEqualTo(placeCreateRequest.getKakaoPid());
     }
@@ -96,12 +90,11 @@ class PlaceCommandServiceTest {
     @Test
     void givenPlaceRequestInfoWithMemberId_whenCreateAlreadyExistsPlace_thenThrowPlaceAlreadyExistsException() {
         // given
-        long memberId = 1L;
         PlaceCreateRequest placeCreateRequest = createPlaceRequest();
         given(placeRepository.existsByKakaoPid(placeCreateRequest.getKakaoPid())).willReturn(true);
 
         // when
-        Throwable t = catchThrowable(() -> sut.create(memberId, placeCreateRequest));
+        Throwable t = catchThrowable(() -> sut.create(placeCreateRequest));
 
         // then
         then(placeRepository).should().existsByKakaoPid(placeCreateRequest.getKakaoPid());
@@ -139,7 +132,6 @@ class PlaceCommandServiceTest {
         then(webScrapingService).shouldHaveNoMoreInteractions();
         then(placeRepository).shouldHaveNoMoreInteractions();
         then(openingHoursRepository).shouldHaveNoMoreInteractions();
-        then(bookmarkQueryService).shouldHaveNoMoreInteractions();
         then(reviewKeywordRepository).shouldHaveNoMoreInteractions();
     }
 

--- a/src/test/java/com/zelusik/eatery/unit/domain/place/service/PlaceQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/place/service/PlaceQueryServiceTest.java
@@ -5,6 +5,7 @@ import com.zelusik.eatery.domain.place.constant.FilteringType;
 import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
 import com.zelusik.eatery.domain.place.dto.PlaceFilteringKeywordDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusAndImagesDto;
 import com.zelusik.eatery.domain.place.dto.request.FindNearPlacesFilteringConditionRequest;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Place;
@@ -169,14 +170,14 @@ class PlaceQueryServiceTest {
         FilteringType filteringType = FilteringType.SECOND_CATEGORY;
         String filteringKeyword = "고기,육류";
         Pageable pageable = Pageable.ofSize(30);
-        PageImpl<PlaceDto> expectedResult = new PageImpl<>(List.of(createPlaceDto(placeId)));
-        given(placeRepository.findMarkedPlaces(memberId, filteringType, filteringKeyword, MAX_NUM_OF_PLACE_IMAGES, pageable)).willReturn(expectedResult);
+        PageImpl<PlaceWithMarkedStatusAndImagesDto> expectedResult = new PageImpl<>(List.of(createPlaceWithMarkedStatusAndImagesDto(placeId)));
+        given(placeRepository.findMarkedDtosWithoutOpeningHours(memberId, filteringType, filteringKeyword, MAX_NUM_OF_PLACE_IMAGES, pageable)).willReturn(expectedResult);
 
         // when
-        Slice<PlaceDto> actualResult = sut.findMarkedDtos(memberId, filteringType, filteringKeyword, pageable);
+        Slice<PlaceWithMarkedStatusAndImagesDto> actualResult = sut.findMarkedDtosWithoutOpeningHours(memberId, filteringType, filteringKeyword, pageable);
 
         // then
-        then(placeRepository).should().findMarkedPlaces(memberId, filteringType, filteringKeyword, MAX_NUM_OF_PLACE_IMAGES, pageable);
+        then(placeRepository).should().findMarkedDtosWithoutOpeningHours(memberId, filteringType, filteringKeyword, MAX_NUM_OF_PLACE_IMAGES, pageable);
         verifyEveryMocksShouldHaveNoMoreInteractions();
         assertThat(actualResult.getSize()).isEqualTo(expectedResult.getSize());
         assertThat(actualResult.getContent().get(0).getId()).isEqualTo(placeId);
@@ -218,14 +219,14 @@ class PlaceQueryServiceTest {
                 ReviewKeywordValue.WITH_ALCOHOL,
                 false
         );
-        Page<PlaceDto> expectedResult = new PageImpl<>(List.of(createPlaceDto(2L)), pageable, 1);
-        given(placeRepository.findDtosNearBy(memberId, filteringCondition, point, 50, MAX_NUM_OF_PLACE_IMAGES, pageable)).willReturn(expectedResult);
+        Page<PlaceWithMarkedStatusAndImagesDto> expectedResult = new PageImpl<>(List.of(createPlaceWithMarkedStatusAndImagesDto(2L)), pageable, 1);
+        given(placeRepository.findDtosWithoutOpeningHoursNearBy(memberId, filteringCondition, point, 50, MAX_NUM_OF_PLACE_IMAGES, pageable)).willReturn(expectedResult);
 
         // when
-        Slice<PlaceDto> actualResult = sut.findDtosNearBy(memberId, filteringCondition, point, pageable);
+        Slice<PlaceWithMarkedStatusAndImagesDto> actualResult = sut.findDtosWithoutOpeningHoursNearBy(memberId, filteringCondition, point, pageable);
 
         // then
-        then(placeRepository).should().findDtosNearBy(memberId, filteringCondition, point, 50, MAX_NUM_OF_PLACE_IMAGES, pageable);
+        then(placeRepository).should().findDtosWithoutOpeningHoursNearBy(memberId, filteringCondition, point, 50, MAX_NUM_OF_PLACE_IMAGES, pageable);
         verifyEveryMocksShouldHaveNoMoreInteractions();
         assertThat(actualResult.getSize()).isEqualTo(expectedResult.getSize());
         assertThat(actualResult.getContent().get(0).getId()).isEqualTo(expectedResult.getContent().get(0).getId());
@@ -297,23 +298,23 @@ class PlaceQueryServiceTest {
         return createPlace(id, kakaoPid, null, null);
     }
 
-    private PlaceDto createPlaceDto(Long placeId) {
-        return new PlaceDto(
+    private PlaceWithMarkedStatusAndImagesDto createPlaceWithMarkedStatusAndImagesDto(long placeId) {
+        return new PlaceWithMarkedStatusAndImagesDto(
                 placeId,
                 List.of(ReviewKeywordValue.FRESH),
                 "308342289",
                 "연남토마 본점",
-                "http://place.map.kakao.com/308342289",
+                "https://place.map.kakao.com/308342289",
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
                 Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
-                "http://place.map.kakao.com/308342289",
+                "https://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,
                 List.of(),
-                null,
-                false
+                false,
+                List.of()
         );
     }
 }

--- a/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/api/RecommendedReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/api/RecommendedReviewControllerTest.java
@@ -7,7 +7,7 @@ import com.zelusik.eatery.domain.member.constant.LoginType;
 import com.zelusik.eatery.domain.member.constant.RoleType;
 import com.zelusik.eatery.domain.member.dto.MemberDto;
 import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
@@ -18,7 +18,7 @@ import com.zelusik.eatery.domain.recommended_review.dto.request.SaveRecommendedR
 import com.zelusik.eatery.domain.recommended_review.service.RecommendedReviewCommandService;
 import com.zelusik.eatery.domain.recommended_review.service.RecommendedReviewQueryService;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.global.common.constant.EateryConstants;
 import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
@@ -77,7 +77,7 @@ class RecommendedReviewControllerTest {
         long placeId = 3L;
         short ranking = 3;
         SaveRecommendedReviewsRequest request = new SaveRecommendedReviewsRequest(reviewId, ranking);
-        RecommendedReviewDto expectedResult = createRecommendedReviewDto(4L, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceDto(placeId)), ranking);
+        RecommendedReviewDto expectedResult = createRecommendedReviewDto(4L, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceWithMarkedStatusDto(placeId)), ranking);
         given(recommendedReviewCommandService.saveRecommendedReview(memberId, reviewId, ranking)).willReturn(expectedResult);
 
         // when & then
@@ -125,7 +125,7 @@ class RecommendedReviewControllerTest {
         long recommendedReviewId = 4L;
         long reviewId = 5L;
         short ranking = 6;
-        List<RecommendedReviewDto> expectedResults = List.of(createRecommendedReviewDto(recommendedReviewId, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceDto(placeId)), ranking));
+        List<RecommendedReviewDto> expectedResults = List.of(createRecommendedReviewDto(recommendedReviewId, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceWithMarkedStatusDto(placeId)), ranking));
         given(recommendedReviewQueryService.findAllDtosWithPlaceMarkedStatus(memberId)).willReturn(expectedResults);
 
         // when & then
@@ -153,7 +153,7 @@ class RecommendedReviewControllerTest {
                 new BatchUpdateRecommendedReviewsRequest.RecommendedReviewRequest(4L, (short) 3)
         ));
         MemberDto member = createMemberDto(memberId);
-        PlaceDto place = createPlaceDto(placeId);
+        PlaceWithMarkedStatusDto place = createPlaceWithMarkedStatusDto(placeId);
         List<RecommendedReviewDto> expectedResults = List.of(
                 createRecommendedReviewDto(5L, memberId, createReviewDto(3L, member, place), (short) 1),
                 createRecommendedReviewDto(6L, memberId, createReviewDto(4L, member, place), (short) 2),
@@ -221,28 +221,27 @@ class RecommendedReviewControllerTest {
         );
     }
 
-    private PlaceDto createPlaceDto(Long placeId) {
-        return new PlaceDto(
+    private PlaceWithMarkedStatusDto createPlaceWithMarkedStatusDto(long placeId) {
+        return new PlaceWithMarkedStatusDto(
                 placeId,
                 List.of(ReviewKeywordValue.FRESH),
                 "308342289",
                 "연남토마 본점",
-                "http://place.map.kakao.com/308342289",
+                "https://place.map.kakao.com/308342289",
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
                 Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
-                "http://place.map.kakao.com/308342289",
+                "https://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,
                 List.of(),
-                null,
                 false
         );
     }
 
-    private ReviewDto createReviewDto(long reviewId, MemberDto writer, PlaceDto place) {
-        return new ReviewDto(
+    private ReviewWithPlaceMarkedStatusDto createReviewDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
+        return new ReviewWithPlaceMarkedStatusDto(
                 reviewId,
                 writer,
                 place,
@@ -266,7 +265,7 @@ class RecommendedReviewControllerTest {
         );
     }
 
-    private RecommendedReviewDto createRecommendedReviewDto(long id, long memberId, ReviewDto review, short ranking) {
+    private RecommendedReviewDto createRecommendedReviewDto(long id, long memberId, ReviewWithPlaceMarkedStatusDto review, short ranking) {
         return new RecommendedReviewDto(id, memberId, review, ranking);
     }
 }

--- a/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/api/RecommendedReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/api/RecommendedReviewControllerTest.java
@@ -13,11 +13,13 @@ import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
 import com.zelusik.eatery.domain.recommended_review.api.RecommendedReviewController;
 import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import com.zelusik.eatery.domain.recommended_review.dto.request.BatchUpdateRecommendedReviewsRequest;
 import com.zelusik.eatery.domain.recommended_review.dto.request.SaveRecommendedReviewsRequest;
 import com.zelusik.eatery.domain.recommended_review.service.RecommendedReviewCommandService;
 import com.zelusik.eatery.domain.recommended_review.service.RecommendedReviewQueryService;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.domain.review.dto.ReviewDto;
 import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.global.common.constant.EateryConstants;
@@ -125,7 +127,14 @@ class RecommendedReviewControllerTest {
         long recommendedReviewId = 4L;
         long reviewId = 5L;
         short ranking = 6;
-        List<RecommendedReviewDto> expectedResults = List.of(createRecommendedReviewDto(recommendedReviewId, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceWithMarkedStatusDto(placeId)), ranking));
+        List<RecommendedReviewWithPlaceDto> expectedResults = List.of(
+                createRecommendedReviewWithPlaceDto(
+                        recommendedReviewId,
+                        memberId,
+                        createReviewWithPlaceMarkedStatusDto(reviewId, createMemberDto(memberId), createPlaceWithMarkedStatusDto(placeId)),
+                        ranking
+                )
+        );
         given(recommendedReviewQueryService.findAllDtosWithPlaceMarkedStatus(memberId)).willReturn(expectedResults);
 
         // when & then
@@ -240,8 +249,8 @@ class RecommendedReviewControllerTest {
         );
     }
 
-    private ReviewWithPlaceMarkedStatusDto createReviewDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
-        return new ReviewWithPlaceMarkedStatusDto(
+    private ReviewDto createReviewDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
+        return new ReviewDto(
                 reviewId,
                 writer,
                 place,
@@ -249,6 +258,26 @@ class RecommendedReviewControllerTest {
                 "자동 생성된 내용",
                 "제출된 내용",
                 List.of(createReviewImageDto(100L, reviewId)),
+                LocalDateTime.now()
+        );
+    }
+
+    private ReviewWithPlaceMarkedStatusDto createReviewWithPlaceMarkedStatusDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
+        return new ReviewWithPlaceMarkedStatusDto(
+                reviewId,
+                writer,
+                place,
+                List.of(ReviewKeywordValue.NOISY, ReviewKeywordValue.FRESH),
+                "자동 생성된 내용",
+                "제출된 내용",
+                List.of(new ReviewImageDto(
+                        1L,
+                        1L,
+                        "test.txt",
+                        "storedName",
+                        "url",
+                        "thumbnailStoredName",
+                        "thumbnailUrl")),
                 LocalDateTime.now()
         );
     }
@@ -265,7 +294,11 @@ class RecommendedReviewControllerTest {
         );
     }
 
-    private RecommendedReviewDto createRecommendedReviewDto(long id, long memberId, ReviewWithPlaceMarkedStatusDto review, short ranking) {
+    private RecommendedReviewDto createRecommendedReviewDto(long id, long memberId, ReviewDto review, short ranking) {
         return new RecommendedReviewDto(id, memberId, review, ranking);
+    }
+
+    private RecommendedReviewWithPlaceDto createRecommendedReviewWithPlaceDto(long id, long memberId, ReviewWithPlaceMarkedStatusDto review, short ranking) {
+        return new RecommendedReviewWithPlaceDto(id, memberId, review, ranking);
     }
 }

--- a/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/service/RecommendedReviewQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/service/RecommendedReviewQueryServiceTest.java
@@ -5,7 +5,7 @@ import com.zelusik.eatery.domain.member.constant.LoginType;
 import com.zelusik.eatery.domain.member.constant.RoleType;
 import com.zelusik.eatery.domain.member.dto.MemberDto;
 import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
-import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
@@ -13,7 +13,7 @@ import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
 import com.zelusik.eatery.domain.recommended_review.repository.RecommendedReviewRepository;
 import com.zelusik.eatery.domain.recommended_review.service.RecommendedReviewQueryService;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review_image.dto.ReviewImageDto;
 import com.zelusik.eatery.global.common.constant.EateryConstants;
 import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
@@ -52,7 +52,7 @@ class RecommendedReviewQueryServiceTest {
         long recommendedReviewId = 3L;
         long reviewId = 4L;
         short ranking = 3;
-        List<RecommendedReviewDto> expectedResults = List.of(createRecommendedReviewDto(recommendedReviewId, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceDto(placeId)), ranking));
+        List<RecommendedReviewDto> expectedResults = List.of(createRecommendedReviewDto(recommendedReviewId, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceWithMarkedStatusDto(placeId)), ranking));
         given(recommendedReviewRepository.findAllDtosWithPlaceMarkedStatusByMemberId(memberId)).willReturn(expectedResults);
 
         // when
@@ -91,28 +91,27 @@ class RecommendedReviewQueryServiceTest {
         );
     }
 
-    private PlaceDto createPlaceDto(Long placeId) {
-        return new PlaceDto(
+    private PlaceWithMarkedStatusDto createPlaceWithMarkedStatusDto(long placeId) {
+        return new PlaceWithMarkedStatusDto(
                 placeId,
                 List.of(ReviewKeywordValue.FRESH),
                 "308342289",
                 "연남토마 본점",
-                "http://place.map.kakao.com/308342289",
+                "https://place.map.kakao.com/308342289",
                 KakaoCategoryGroupCode.FD6,
                 PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
                 "02-332-8064",
                 Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
-                "http://place.map.kakao.com/308342289",
+                "https://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,
                 List.of(),
-                null,
                 false
         );
     }
 
-    private ReviewDto createReviewDto(long reviewId, MemberDto writer, PlaceDto place) {
-        return new ReviewDto(
+    private ReviewWithPlaceMarkedStatusDto createReviewDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
+        return new ReviewWithPlaceMarkedStatusDto(
                 reviewId,
                 writer,
                 place,
@@ -131,7 +130,7 @@ class RecommendedReviewQueryServiceTest {
         );
     }
 
-    private RecommendedReviewDto createRecommendedReviewDto(long id, long memberId, ReviewDto review, short ranking) {
+    private RecommendedReviewDto createRecommendedReviewDto(long id, long memberId, ReviewWithPlaceMarkedStatusDto review, short ranking) {
         return new RecommendedReviewDto(
                 id,
                 memberId,

--- a/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/service/RecommendedReviewQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/service/RecommendedReviewQueryServiceTest.java
@@ -9,7 +9,7 @@ import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
-import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewDto;
+import com.zelusik.eatery.domain.recommended_review.dto.RecommendedReviewWithPlaceDto;
 import com.zelusik.eatery.domain.recommended_review.repository.RecommendedReviewRepository;
 import com.zelusik.eatery.domain.recommended_review.service.RecommendedReviewQueryService;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
@@ -52,11 +52,11 @@ class RecommendedReviewQueryServiceTest {
         long recommendedReviewId = 3L;
         long reviewId = 4L;
         short ranking = 3;
-        List<RecommendedReviewDto> expectedResults = List.of(createRecommendedReviewDto(recommendedReviewId, memberId, createReviewDto(reviewId, createMemberDto(memberId), createPlaceWithMarkedStatusDto(placeId)), ranking));
+        List<RecommendedReviewWithPlaceDto> expectedResults = List.of(createRecommendedReviewDto(recommendedReviewId, memberId, createReviewWithPlaceMarkedStatusDto(reviewId, createMemberDto(memberId), createPlaceWithMarkedStatusDto(placeId)), ranking));
         given(recommendedReviewRepository.findAllDtosWithPlaceMarkedStatusByMemberId(memberId)).willReturn(expectedResults);
 
         // when
-        List<RecommendedReviewDto> actualResults = sut.findAllDtosWithPlaceMarkedStatus(memberId);
+        List<RecommendedReviewWithPlaceDto> actualResults = sut.findAllDtosWithPlaceMarkedStatus(memberId);
 
         // then
         then(recommendedReviewRepository).should().findAllDtosWithPlaceMarkedStatusByMemberId(memberId);
@@ -110,7 +110,7 @@ class RecommendedReviewQueryServiceTest {
         );
     }
 
-    private ReviewWithPlaceMarkedStatusDto createReviewDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
+    private ReviewWithPlaceMarkedStatusDto createReviewWithPlaceMarkedStatusDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
         return new ReviewWithPlaceMarkedStatusDto(
                 reviewId,
                 writer,
@@ -130,8 +130,8 @@ class RecommendedReviewQueryServiceTest {
         );
     }
 
-    private RecommendedReviewDto createRecommendedReviewDto(long id, long memberId, ReviewWithPlaceMarkedStatusDto review, short ranking) {
-        return new RecommendedReviewDto(
+    private RecommendedReviewWithPlaceDto createRecommendedReviewDto(long id, long memberId, ReviewWithPlaceMarkedStatusDto review, short ranking) {
+        return new RecommendedReviewWithPlaceDto(
                 id,
                 memberId,
                 review,

--- a/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewCommandServiceTest.java
@@ -14,7 +14,7 @@ import com.zelusik.eatery.domain.place.entity.Point;
 import com.zelusik.eatery.domain.place.service.PlaceCommandService;
 import com.zelusik.eatery.domain.place.service.PlaceQueryService;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review.dto.request.ReviewCreateRequest;
 import com.zelusik.eatery.domain.review.entity.Review;
 import com.zelusik.eatery.domain.review.exception.ReviewDeletePermissionDeniedException;
@@ -99,7 +99,7 @@ class ReviewCommandServiceTest {
         willDoNothing().given(placeCommandService).renewTop3Keywords(expectedPlace);
 
         // when
-        ReviewDto actualSavedReview = sut.create(writerId, reviewCreateRequest);
+        ReviewWithPlaceMarkedStatusDto actualSavedReview = sut.create(writerId, reviewCreateRequest);
 
         // then
         then(placeQueryService).should().findById(placeId);
@@ -268,7 +268,7 @@ class ReviewCommandServiceTest {
     }
 
     private ReviewCreateRequest createReviewCreateRequest(long placeId) {
-        return ReviewCreateRequest.of(
+        return new ReviewCreateRequest(
                 placeId,
                 List.of(ReviewKeywordValue.FRESH),
                 "자동 생성된 내용",

--- a/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewQueryServiceTest.java
@@ -8,12 +8,13 @@ import com.zelusik.eatery.domain.member.dto.MemberDto;
 import com.zelusik.eatery.domain.member.entity.Member;
 import com.zelusik.eatery.domain.place.constant.KakaoCategoryGroupCode;
 import com.zelusik.eatery.domain.place.dto.PlaceDto;
+import com.zelusik.eatery.domain.place.dto.PlaceWithMarkedStatusDto;
 import com.zelusik.eatery.domain.place.entity.Address;
 import com.zelusik.eatery.domain.place.entity.Place;
 import com.zelusik.eatery.domain.place.entity.PlaceCategory;
 import com.zelusik.eatery.domain.place.entity.Point;
 import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.review.dto.ReviewDto;
+import com.zelusik.eatery.domain.review.dto.ReviewWithPlaceMarkedStatusDto;
 import com.zelusik.eatery.domain.review.entity.Review;
 import com.zelusik.eatery.domain.review.exception.ReviewNotFoundException;
 import com.zelusik.eatery.domain.review.repository.ReviewRepository;
@@ -103,7 +104,7 @@ class ReviewQueryServiceTest {
         given(bookmarkQueryService.isMarkedPlace(eq(memberId), any(Place.class))).willReturn(false);
 
         // when
-        ReviewDto actualResult = sut.findDtoById(memberId, reviewId);
+        ReviewWithPlaceMarkedStatusDto actualResult = sut.findDtoById(memberId, reviewId);
 
         // then
         then(reviewRepository).should().findByIdAndDeletedAtNull(reviewId);
@@ -121,12 +122,12 @@ class ReviewQueryServiceTest {
         long loginMemberId = 1L;
         Pageable pageable = Pageable.ofSize(15);
         MemberDto member = createMemberDto(3L);
-        PlaceDto place = createPlaceDto(4L, "12345");
-        Slice<ReviewDto> expectedSearchResult = new SliceImpl<>(List.of(createReviewDto(2L, member, place)));
+        PlaceWithMarkedStatusDto place = createPlaceWithMarkedStatusDto(4L, "12345");
+        Slice<ReviewWithPlaceMarkedStatusDto> expectedSearchResult = new SliceImpl<>(List.of(createReviewDto(2L, member, place)));
         given(reviewRepository.findDtos(loginMemberId, null, null, List.of(WRITER, PLACE), pageable)).willReturn(expectedSearchResult);
 
         // when
-        Slice<ReviewDto> actualSearchResult = sut.findDtos(loginMemberId, null, null, List.of(WRITER, PLACE), pageable);
+        Slice<ReviewWithPlaceMarkedStatusDto> actualSearchResult = sut.findDtos(loginMemberId, null, null, List.of(WRITER, PLACE), pageable);
 
         // then
         then(reviewRepository).should().findDtos(loginMemberId, null, null, List.of(WRITER, PLACE), pageable);
@@ -142,12 +143,12 @@ class ReviewQueryServiceTest {
         long reviewId = 2L;
         Pageable pageable = Pageable.ofSize(10);
         MemberDto writer = createMemberDto(3L);
-        PlaceDto place = createPlaceDto(4L, "123");
-        Slice<ReviewDto> expectedResults = new SliceImpl<>(List.of(createReviewDto(reviewId, writer, place)), pageable, false);
+        PlaceWithMarkedStatusDto place = createPlaceWithMarkedStatusDto(4L, "123");
+        Slice<ReviewWithPlaceMarkedStatusDto> expectedResults = new SliceImpl<>(List.of(createReviewDto(reviewId, writer, place)), pageable, false);
         given(reviewRepository.findReviewFeed(loginMemberId, pageable)).willReturn(expectedResults);
 
         // when
-        Slice<ReviewDto> actualResults = sut.findReviewReed(loginMemberId, Pageable.ofSize(10));
+        Slice<ReviewWithPlaceMarkedStatusDto> actualResults = sut.findReviewReed(loginMemberId, Pageable.ofSize(10));
 
         // then
         then(reviewRepository).should().findReviewFeed(loginMemberId, pageable);
@@ -238,8 +239,25 @@ class ReviewQueryServiceTest {
                 "http://place.map.kakao.com/308342289",
                 new Point("37.5595073462493", "126.921462488105"),
                 null,
-                List.of(),
+                List.of()
+        );
+    }
+
+    private PlaceWithMarkedStatusDto createPlaceWithMarkedStatusDto(long placeId, String kakaoPid) {
+        return new PlaceWithMarkedStatusDto(
+                placeId,
+                List.of(ReviewKeywordValue.FRESH),
+                kakaoPid,
+                "연남토마 본점",
+                "https://place.map.kakao.com/308342289",
+                KakaoCategoryGroupCode.FD6,
+                PlaceCategory.of("음식점 > 퓨전요리 > 퓨전일식"),
+                "02-332-8064",
+                Address.of("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                "https://place.map.kakao.com/308342289",
+                new Point("37.5595073462493", "126.921462488105"),
                 null,
+                List.of(),
                 false
         );
     }
@@ -257,8 +275,8 @@ class ReviewQueryServiceTest {
         );
     }
 
-    public static ReviewDto createReviewDto(long reviewId, MemberDto writer, PlaceDto place) {
-        return new ReviewDto(
+    public static ReviewWithPlaceMarkedStatusDto createReviewDto(long reviewId, MemberDto writer, PlaceWithMarkedStatusDto place) {
+        return new ReviewWithPlaceMarkedStatusDto(
                 reviewId,
                 writer,
                 place,

--- a/src/test/java/com/zelusik/eatery/unit/global/scraping/service/WebScrapingServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/global/scraping/service/WebScrapingServiceTest.java
@@ -3,8 +3,8 @@ package com.zelusik.eatery.unit.global.scraping.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zelusik.eatery.domain.place.constant.DayOfWeek;
-import com.zelusik.eatery.domain.place.dto.PlaceScrapingOpeningHourDto;
-import com.zelusik.eatery.domain.place.dto.PlaceScrapingInfo;
+import com.zelusik.eatery.global.scraping.dto.PlaceScrapingOpeningHourDto;
+import com.zelusik.eatery.global.scraping.dto.KakaoPlaceScrapingInfo;
 import com.zelusik.eatery.global.scraping.service.WebScrapingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,7 +62,7 @@ class WebScrapingServiceTest {
                 ));
 
         // when
-        PlaceScrapingInfo result = sut.getPlaceScrapingInfo(kakaoPid);
+        KakaoPlaceScrapingInfo result = sut.getPlaceScrapingInfo(kakaoPid);
 
         // then
         restServer.verify();
@@ -99,8 +99,8 @@ class WebScrapingServiceTest {
                 .hasSize(3);
     }
 
-    private static PlaceScrapingInfo createPlaceScrapingResponse() {
-        return PlaceScrapingInfo.of(
+    private static KakaoPlaceScrapingInfo createPlaceScrapingResponse() {
+        return KakaoPlaceScrapingInfo.of(
                 List.of(
                         PlaceScrapingOpeningHourDto.of(DayOfWeek.MON, LocalTime.of(12, 0), LocalTime.of(21, 0)),
                         PlaceScrapingOpeningHourDto.of(DayOfWeek.TUE, LocalTime.of(12, 0), LocalTime.of(21, 0)),


### PR DESCRIPTION
## 🔥 Related Issue
- Close #388

## 🏃‍ Task
- Dto 중 entity에 포함되지 않은 필드를 XxxWithXxxDto의 별도 dto로 분리
  - `MemberProfileDto` => `MemberWithProfileInfoDto`로 이름 수정 후 `MemberDto`를 상속받도록 변경
  - `PlaceDto`를 장소 북마크 여부, 장소 대표 이미지 포함 여부에 따라 세 개의 dto로 분리
  - 장소 북마크 여부 포함을 기준으로 추천 리뷰 dto를 두개로 분리

## 📄 Reference
- None
