### PR TITLE
Spring Actuator 관련 API를 logging 대상에서 제외

### DIFF
--- a/src/main/java/com/zelusik/eatery/global/log/filter/LogApiInfoFilter.java
+++ b/src/main/java/com/zelusik/eatery/global/log/filter/LogApiInfoFilter.java
@@ -21,7 +21,8 @@ public class LogApiInfoFilter extends OncePerRequestFilter {
 
     private static final String[] LOG_BLACK_LIST = {
             "/swagger",
-            "/v3/api-docs"
+            "/v3/api-docs",
+            "/actuator"
     };
 
     private static final List<MediaType> VISIBLE_TYPES = Arrays.asList(


### PR DESCRIPTION
## 🔥 Related Issue
- Close #384

## 🏃‍ Task
- Spring Actuator 관련 API를 logging 대상에서 제외

## 📄 Reference
- None
