### PR TITLE
이미지 등의 resource 로딩 속도 향상을 위한 AWS Cloud Front(CDN) 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation 'com.github.downgoon:marvin:1.5.5'
     implementation 'com.github.downgoon:MarvinPlugins:1.5.5'
 
+    // Spring Configuration Processor
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
     // Spring Boot Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/java/com/zelusik/eatery/EateryApplication.java
+++ b/src/main/java/com/zelusik/eatery/EateryApplication.java
@@ -2,8 +2,10 @@ package com.zelusik.eatery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.PropertySource;
 
+@ConfigurationPropertiesScan
 @PropertySource("classpath:/env.properties")
 @SpringBootApplication
 public class EateryApplication {
@@ -11,5 +13,4 @@ public class EateryApplication {
     public static void main(String[] args) {
         SpringApplication.run(EateryApplication.class, args);
     }
-
 }

--- a/src/main/java/com/zelusik/eatery/global/common/properties/AWSProperties.java
+++ b/src/main/java/com/zelusik/eatery/global/common/properties/AWSProperties.java
@@ -1,0 +1,10 @@
+package com.zelusik.eatery.global.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cloud.aws")
+public record AWSProperties(CloudFront cloudFront) {
+
+    public record CloudFront(String domainName) {
+    }
+}

--- a/src/main/java/com/zelusik/eatery/global/common/properties/AWSProperties.java
+++ b/src/main/java/com/zelusik/eatery/global/common/properties/AWSProperties.java
@@ -3,7 +3,13 @@ package com.zelusik.eatery.global.common.properties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("cloud.aws")
-public record AWSProperties(CloudFront cloudFront) {
+public record AWSProperties(
+        S3 s3,
+        CloudFront cloudFront
+) {
+
+    public record S3(String bucketName) {
+    }
 
     public record CloudFront(String domainName) {
     }

--- a/src/main/java/com/zelusik/eatery/global/file/service/S3FileService.java
+++ b/src/main/java/com/zelusik/eatery/global/file/service/S3FileService.java
@@ -4,11 +4,12 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.zelusik.eatery.global.common.exception.MultipartFileNotReadableException;
+import com.zelusik.eatery.global.common.exception.ThumbnailImageCreationException;
+import com.zelusik.eatery.global.common.properties.AWSProperties;
+import com.zelusik.eatery.global.file.CustomMultipartFile;
 import com.zelusik.eatery.global.file.dto.S3FileDto;
 import com.zelusik.eatery.global.file.dto.S3ImageDto;
-import com.zelusik.eatery.global.file.CustomMultipartFile;
-import com.zelusik.eatery.global.common.exception.ThumbnailImageCreationException;
-import com.zelusik.eatery.global.common.exception.MultipartFileNotReadableException;
 import lombok.RequiredArgsConstructor;
 import marvin.image.MarvinImage;
 import org.marvinproject.image.transform.scale.Scale;
@@ -32,6 +33,7 @@ public class S3FileService {
     private static final int THUMBNAIL_IMAGE_WIDTH = 500;
 
     private final AmazonS3Client s3Client;
+    private final AWSProperties awsProperties;
 
     @Value("${cloud.aws.s3.bucket-name}")
     private String bucketName;
@@ -59,15 +61,13 @@ public class S3FileService {
             throw new MultipartFileNotReadableException(ex);
         }
 
-        s3Client.putObject(
-                new PutObjectRequest(
-                        bucketName,
-                        storeFileName,
-                        inputStream,
-                        objectMetadata
-                ).withCannedAcl(CannedAccessControlList.PublicRead)
-        );
-        String storedFileUrl = s3Client.getResourceUrl(bucketName, storeFileName);
+        s3Client.putObject(new PutObjectRequest(
+                bucketName,
+                storeFileName,
+                inputStream,
+                objectMetadata
+        ).withCannedAcl(CannedAccessControlList.PublicRead));
+        String storedFileUrl = awsProperties.cloudFront().domainName() + storeFileName;
 
         return S3FileDto.of(originalFilename, storeFileName, storedFileUrl);
     }

--- a/src/main/java/com/zelusik/eatery/global/file/service/S3FileService.java
+++ b/src/main/java/com/zelusik/eatery/global/file/service/S3FileService.java
@@ -13,7 +13,6 @@ import com.zelusik.eatery.global.file.dto.S3ImageDto;
 import lombok.RequiredArgsConstructor;
 import marvin.image.MarvinImage;
 import org.marvinproject.image.transform.scale.Scale;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,9 +33,6 @@ public class S3FileService {
 
     private final AmazonS3Client s3Client;
     private final AWSProperties awsProperties;
-
-    @Value("${cloud.aws.s3.bucket-name}")
-    private String bucketName;
 
     /**
      * MultipartFile을 전달받아 S3 bucket에 업로드한다.
@@ -62,7 +58,7 @@ public class S3FileService {
         }
 
         s3Client.putObject(new PutObjectRequest(
-                bucketName,
+                awsProperties.s3().bucketName(),
                 storeFileName,
                 inputStream,
                 objectMetadata

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,3 +47,4 @@ cloud.aws.credentials.access-key=${S3_IAM_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${S3_IAM_SECRET_KEY}
 cloud.aws.stack.auto=false
 cloud.aws.region.static=ap-northeast-2
+cloud.aws.cloud-front.domain-name=${AWS_CLOUD_FRONT_DOMAIN_NAME}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## 🔥 Related Issue
- Close #321

## 🏃‍ Task
- Spring Configuration Processor 의존성 추가 및 설정
- AWS 관련 properties를 불러오는 기존 코드를 Spring Configuration Processor를 활용한 코드로 수정
- 이미지 업로드 시 resource의 access url을 cloud front로 설정하여 entity가 저장되도록 수정

## 📄 Reference
- [Final class(`AWSProperties`와 같은 record type)도 mocking 할 수 있도록 mockito 설정 추가](https://shanepark.tistory.com/422)
