### PR TITLE
회원 닉네임 정책 적용하여 코드 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/member/api/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/api/MemberController.java
@@ -136,9 +136,14 @@ public class MemberController {
             summary = "내 정보 수정",
             description = "<p><strong>Latest version: v1.1</strong>" +
                           "<p>내 정보를 수정합니다." +
-                          "<p>프로필 이미지는 수정하고자 하는 경우에만 요청해야 하고, 수정하지 않는 경우 요청 데이터에서 제외해야합니다.",
+                          "<p>프로필 이미지는 수정하고자 하는 경우에만 요청 데이터에 포함하고, 수정하지 않는 경우 요청 데이터에서 제외해야합니다.",
             security = @SecurityRequirement(name = "access-token")
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "409", description = "이미 사용중인 닉네임인 경우"),
+            @ApiResponse(responseCode = "422", description = "유효하지 않은 닉네임인 경우.", content = @Content)
+    })
     @PutMapping(value = "/v1/members", headers = API_MINOR_VERSION_HEADER_NAME + "=1", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public MemberResponse updateMemberV1_1(
             @AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/MemberDto.java
@@ -72,4 +72,8 @@ public class MemberDto {
                 this.getGender()
         );
     }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/zelusik/eatery/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/dto/MemberDto.java
@@ -60,7 +60,7 @@ public class MemberDto {
     }
 
     public Member toEntity() {
-        return Member.of(
+        return Member.create(
                 this.getProfileImageUrl(),
                 this.getProfileThumbnailImageUrl(),
                 this.getSocialUid(),

--- a/src/main/java/com/zelusik/eatery/domain/member/entity/Member.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/entity/Member.java
@@ -9,10 +9,12 @@ import com.zelusik.eatery.global.common.entity.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import javax.validation.constraints.NotNull;
 import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.LinkedList;
@@ -34,34 +36,36 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id", nullable = false)
     private Long id;
 
-    @Column(nullable = false)
+    @NotBlank
     private String profileImageUrl;
 
-    @Column(nullable = false)
+    @NotBlank
     private String profileThumbnailImageUrl;
 
-    @Column(nullable = false, unique = true)
+    @NotBlank
+    @Column(unique = true)
     private String socialUid;
 
-    @Column(nullable = false)
+    @NotNull
     @Enumerated(EnumType.STRING)
     private LoginType loginType;
 
-    @Column(nullable = false)
+    @NotEmpty
     @Convert(converter = RoleTypesConverter.class)
     private Set<RoleType> roleTypes;
 
     private String email;
 
-    @Column(nullable = false, length = 15)
-    private String nickname;
+    @NotNull
+    @Embedded
+    private MemberNickname nickname;
 
     private LocalDate birthDay;
 
     private Integer ageRange;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Gender gender;
 
     private LocalDateTime deletedAt;
@@ -69,7 +73,22 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "member")
     private List<FavoriteFoodCategory> favoriteFoodCategories = new LinkedList<>();
 
-    public Member(@Nullable Long id, @NotNull String profileImageUrl, @NotNull String profileThumbnailImageUrl, @NotNull String socialUid, @NotNull LoginType loginType, @NotNull Set<RoleType> roleTypes, @Nullable String email, @NotNull String nickname, @Nullable LocalDate birthDay, @Nullable Integer ageRange, @Nullable Gender gender, @Nullable LocalDateTime createdAt, @Nullable LocalDateTime updatedAt, @Nullable LocalDateTime deletedAt) {
+    public Member(
+            @Nullable Long id,
+            @NotNull String profileImageUrl,
+            @NotNull String profileThumbnailImageUrl,
+            @NotNull String socialUid,
+            @NotNull LoginType loginType,
+            @NotNull Set<RoleType> roleTypes,
+            @Nullable String email,
+            @NotNull String nickname,
+            @Nullable LocalDate birthDay,
+            @Nullable Integer ageRange,
+            @Nullable Gender gender,
+            @Nullable LocalDateTime createdAt,
+            @Nullable LocalDateTime updatedAt,
+            @Nullable LocalDateTime deletedAt
+    ) {
         super(createdAt, updatedAt);
         this.id = id;
         this.profileImageUrl = profileImageUrl;
@@ -78,7 +97,7 @@ public class Member extends BaseTimeEntity {
         this.loginType = loginType;
         this.roleTypes = roleTypes;
         this.email = email;
-        this.nickname = nickname;
+        this.nickname = new MemberNickname(nickname);
         this.birthDay = birthDay;
         this.ageRange = ageRange;
         this.gender = gender;
@@ -99,22 +118,26 @@ public class Member extends BaseTimeEntity {
         return new Member(null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, null, ageRange, gender, null, null, null);
     }
 
+    public String getNickname() {
+        return nickname.getNickname();
+    }
+
     public void update(String profileImageUrl, String profileThumbnailImageUrl, String nickname, LocalDate birthDay, Gender gender) {
         this.profileImageUrl = profileImageUrl;
         this.profileThumbnailImageUrl = profileThumbnailImageUrl;
-        this.nickname = nickname;
+        this.nickname = new MemberNickname(nickname);
         this.birthDay = birthDay;
         this.gender = gender;
     }
 
     public void update(String nickname, LocalDate birthDay, Gender gender) {
-        this.nickname = nickname;
+        this.nickname = new MemberNickname(nickname);
         this.birthDay = birthDay;
         this.gender = gender;
     }
 
     public void rejoin() {
-        this.deletedAt = (null);
+        this.deletedAt = null;
     }
 
     public void softDelete() {

--- a/src/main/java/com/zelusik/eatery/domain/member/entity/Member.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/entity/Member.java
@@ -1,16 +1,15 @@
 package com.zelusik.eatery.domain.member.entity;
 
+import com.zelusik.eatery.domain.favorite_food_category.entity.FavoriteFoodCategory;
 import com.zelusik.eatery.domain.member.constant.Gender;
 import com.zelusik.eatery.domain.member.constant.LoginType;
 import com.zelusik.eatery.domain.member.constant.RoleType;
 import com.zelusik.eatery.domain.member.converter.RoleTypesConverter;
 import com.zelusik.eatery.global.common.entity.BaseTimeEntity;
-import com.zelusik.eatery.domain.favorite_food_category.entity.FavoriteFoodCategory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.lang.NonNull;
+import javax.validation.constraints.NotNull;
 import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
@@ -35,11 +34,9 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id", nullable = false)
     private Long id;
 
-    @Setter(AccessLevel.PRIVATE)
     @Column(nullable = false)
     private String profileImageUrl;
 
-    @Setter(AccessLevel.PRIVATE)
     @Column(nullable = false)
     private String profileThumbnailImageUrl;
 
@@ -56,60 +53,23 @@ public class Member extends BaseTimeEntity {
 
     private String email;
 
-    @Setter(AccessLevel.PRIVATE)
     @Column(nullable = false, length = 15)
     private String nickname;
 
-    @Setter(AccessLevel.PRIVATE)
     private LocalDate birthDay;
 
     private Integer ageRange;
 
-    @Setter(AccessLevel.PRIVATE)
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Gender gender;
 
+    private LocalDateTime deletedAt;
+
     @OneToMany(mappedBy = "member")
     private List<FavoriteFoodCategory> favoriteFoodCategories = new LinkedList<>();
 
-    @Setter(AccessLevel.PRIVATE)
-    private LocalDateTime deletedAt;
-
-    public static Member of(
-            @NonNull String profileImageUrl,
-            @NonNull String profileThumbnailImageUrl,
-            @NonNull String socialUid,
-            @NonNull LoginType loginType,
-            @NonNull Set<RoleType> roleTypes,
-            @Nullable String email,
-            @NonNull String nickname,
-            @Nullable Integer ageRange,
-            @Nullable Gender gender
-    ) {
-        return of(null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, null, ageRange, gender, null, null, null);
-    }
-
-    public static Member of(
-            @Nullable Long id,
-            @NonNull String profileImageUrl,
-            @NonNull String profileThumbnailImageUrl,
-            @NonNull String socialUid,
-            @NonNull LoginType loginType,
-            @NonNull Set<RoleType> roleTypes,
-            @Nullable String email,
-            @NonNull String nickname,
-            @Nullable LocalDate birthDay,
-            @Nullable Integer ageRange,
-            @Nullable Gender gender,
-            @Nullable LocalDateTime createdAt,
-            @Nullable LocalDateTime updatedAt,
-            @Nullable LocalDateTime deletedAt
-    ) {
-        return new Member(id, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, birthDay, ageRange, gender, createdAt, updatedAt, deletedAt);
-    }
-
-    private Member(@Nullable Long id, @NonNull String profileImageUrl, @NonNull String profileThumbnailImageUrl, @NonNull String socialUid, @NonNull LoginType loginType, @NonNull Set<RoleType> roleTypes, @Nullable String email, @NonNull String nickname, @Nullable LocalDate birthDay, @Nullable Integer ageRange, @Nullable Gender gender, @Nullable LocalDateTime createdAt, @Nullable LocalDateTime updatedAt, @Nullable LocalDateTime deletedAt) {
+    public Member(@Nullable Long id, @NotNull String profileImageUrl, @NotNull String profileThumbnailImageUrl, @NotNull String socialUid, @NotNull LoginType loginType, @NotNull Set<RoleType> roleTypes, @Nullable String email, @NotNull String nickname, @Nullable LocalDate birthDay, @Nullable Integer ageRange, @Nullable Gender gender, @Nullable LocalDateTime createdAt, @Nullable LocalDateTime updatedAt, @Nullable LocalDateTime deletedAt) {
         super(createdAt, updatedAt);
         this.id = id;
         this.profileImageUrl = profileImageUrl;
@@ -125,25 +85,39 @@ public class Member extends BaseTimeEntity {
         this.deletedAt = deletedAt;
     }
 
+    public static Member create(
+            @NotNull String profileImageUrl,
+            @NotNull String profileThumbnailImageUrl,
+            @NotNull String socialUid,
+            @NotNull LoginType loginType,
+            @NotNull Set<RoleType> roleTypes,
+            @Nullable String email,
+            @NotNull String nickname,
+            @Nullable Integer ageRange,
+            @Nullable Gender gender
+    ) {
+        return new Member(null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, roleTypes, email, nickname, null, ageRange, gender, null, null, null);
+    }
+
     public void update(String profileImageUrl, String profileThumbnailImageUrl, String nickname, LocalDate birthDay, Gender gender) {
-        this.setProfileImageUrl(profileImageUrl);
-        this.setProfileThumbnailImageUrl(profileThumbnailImageUrl);
-        this.setNickname(nickname);
-        this.setBirthDay(birthDay);
-        this.setGender(gender);
+        this.profileImageUrl = profileImageUrl;
+        this.profileThumbnailImageUrl = profileThumbnailImageUrl;
+        this.nickname = nickname;
+        this.birthDay = birthDay;
+        this.gender = gender;
     }
 
     public void update(String nickname, LocalDate birthDay, Gender gender) {
-        this.setNickname(nickname);
-        this.setBirthDay(birthDay);
-        this.setGender(gender);
+        this.nickname = nickname;
+        this.birthDay = birthDay;
+        this.gender = gender;
     }
 
     public void rejoin() {
-        this.setDeletedAt(null);
+        this.deletedAt = (null);
     }
 
     public void softDelete() {
-        this.setDeletedAt(LocalDateTime.now());
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/zelusik/eatery/domain/member/entity/MemberNickname.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/entity/MemberNickname.java
@@ -1,0 +1,54 @@
+package com.zelusik.eatery.domain.member.entity;
+
+import com.zelusik.eatery.domain.member.exception.InvalidNicknameException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotBlank;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Embeddable
+public class MemberNickname {
+
+
+    private static final int MEMBER_NICKNAME_MIN_LEN = 2;
+    private static final int MEMBER_NICKNAME_MAX_LEN = 15;
+
+    @NotBlank
+    @Column(nullable = false, length = 15)
+    String nickname;
+
+    public MemberNickname(String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o instanceof String that) {
+            return this.getNickname().equals(that);
+        }
+        if (o instanceof MemberNickname that) {
+            return this.getNickname().equals(that.getNickname());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getNickname());
+    }
+
+    private static void validateNickname(String nickname) {
+        int nicknameLength = nickname.length();
+        if (nicknameLength < MEMBER_NICKNAME_MIN_LEN || nicknameLength > MEMBER_NICKNAME_MAX_LEN) {
+            throw new InvalidNicknameException(String.format("%d글자 이상, %d글자 이하의 닉네임을 입력해주세요.", MEMBER_NICKNAME_MIN_LEN, MEMBER_NICKNAME_MAX_LEN));
+        }
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/member/exception/InvalidNicknameException.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/exception/InvalidNicknameException.java
@@ -1,0 +1,11 @@
+package com.zelusik.eatery.domain.member.exception;
+
+import com.zelusik.eatery.global.common.exception.UnprocessableEntityException;
+import com.zelusik.eatery.global.exception.constant.CustomExceptionType;
+
+public class InvalidNicknameException extends UnprocessableEntityException {
+
+    public InvalidNicknameException(String optionalMessage) {
+        super(CustomExceptionType.INVALID_NICKNAME, optionalMessage);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/member/exception/NicknameDuplicationException.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/exception/NicknameDuplicationException.java
@@ -1,0 +1,11 @@
+package com.zelusik.eatery.domain.member.exception;
+
+import com.zelusik.eatery.global.common.exception.ConflictException;
+import com.zelusik.eatery.global.exception.constant.CustomExceptionType;
+
+public class NicknameDuplicationException extends ConflictException {
+
+    public NicknameDuplicationException() {
+        super(CustomExceptionType.NICKNAME_DUPLICATION);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryQCustom {
 
+    boolean existsByNickname(String nickname);
+
     Optional<Member> findByIdAndDeletedAtNull(Long memberId);
 
     Optional<Member> findBySocialUid(String socialUid);

--- a/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/repository/MemberRepositoryQCustomImpl.java
@@ -3,12 +3,12 @@ package com.zelusik.eatery.domain.member.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.zelusik.eatery.domain.member.entity.QMember;
-import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
-import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
-import com.zelusik.eatery.domain.member.entity.Member;
 import com.zelusik.eatery.domain.member.dto.MemberWithProfileInfoDto;
+import com.zelusik.eatery.domain.member.entity.Member;
+import com.zelusik.eatery.domain.member.entity.QMember;
 import com.zelusik.eatery.domain.member.exception.MemberNotFoundByIdException;
+import com.zelusik.eatery.domain.review.constant.ReviewKeywordValue;
+import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -120,7 +120,7 @@ public class MemberRepositoryQCustomImpl implements MemberRepositoryQCustom {
     @Override
     public Slice<Member> searchByKeyword(String searchKeyword, Pageable pageable) {
         List<Member> content = queryFactory.selectFrom(member)
-                .where(isMemberNotDeleted(), member.nickname.containsIgnoreCase(searchKeyword))
+                .where(isMemberNotDeleted(), member.nickname.nickname.containsIgnoreCase(searchKeyword))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();

--- a/src/main/java/com/zelusik/eatery/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/service/MemberQueryService.java
@@ -99,4 +99,14 @@ public class MemberQueryService {
     public MemberWithProfileInfoDto getMemberProfileInfoById(long memberId) {
         return memberRepository.getMemberProfileInfoById(memberId);
     }
+
+    /**
+     * 이미 존재하는 닉네임인지 확인한다.
+     *
+     * @param nickname 존재 여부를 확인할 닉네임
+     * @return 닉네임 존재 여부
+     */
+    public boolean existsByNickname(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
 }

--- a/src/main/java/com/zelusik/eatery/global/common/exception/UnprocessableEntityException.java
+++ b/src/main/java/com/zelusik/eatery/global/common/exception/UnprocessableEntityException.java
@@ -1,0 +1,23 @@
+package com.zelusik.eatery.global.common.exception;
+
+import com.zelusik.eatery.global.exception.constant.CustomExceptionType;
+import org.springframework.http.HttpStatus;
+
+public abstract class UnprocessableEntityException extends CustomException {
+
+    public UnprocessableEntityException(CustomExceptionType exceptionType) {
+        super(HttpStatus.UNPROCESSABLE_ENTITY, exceptionType);
+    }
+
+    public UnprocessableEntityException(CustomExceptionType exceptionType, String optionalMessage) {
+        super(HttpStatus.UNPROCESSABLE_ENTITY, exceptionType, optionalMessage);
+    }
+
+    public UnprocessableEntityException(CustomExceptionType exceptionType, Throwable cause) {
+        super(HttpStatus.UNPROCESSABLE_ENTITY, exceptionType, cause);
+    }
+
+    public UnprocessableEntityException(CustomExceptionType exceptionType, String optionalMessage, Throwable cause) {
+        super(HttpStatus.UNPROCESSABLE_ENTITY, exceptionType, optionalMessage, cause);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/global/exception/constant/CustomExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/constant/CustomExceptionType.java
@@ -56,6 +56,8 @@ public enum CustomExceptionType {
      * 회원({@link Member}) 관련 예외
      */
     MEMBER_NOT_FOUND(2000, "회원을 찾을 수 없습니다."),
+    INVALID_NICKNAME(2001, "유효하지 않은 닉네임입니다."),
+    NICKNAME_DUPLICATION(2002, "이미 사용중인 닉네임입니다."),
 
     /**
      * 장소({@link Place}) 관련 예외

--- a/src/main/java/com/zelusik/eatery/global/util/NicknameGenerator.java
+++ b/src/main/java/com/zelusik/eatery/global/util/NicknameGenerator.java
@@ -1,16 +1,20 @@
 package com.zelusik.eatery.global.util;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class NicknameGenerator {
+
+    private static final int MIN_NUM_FOR_RANDOM_NICKNAME = 1000;
+    private static final int MAX_NUM_FOR_RANDOM_NICKNAME = 10000;
 
     private static final String[] FLAVOR_LIST = {"달달한", "바삭한", "매콤한", "쫄깃한", "아삭한", "촉촉한", "고소한", "알싸한", "얼얼한", "얼큰한", "진한", "싱거운", "짭잘한", "짭조름한", "담백한", "느끼한", "새콤한", "신선한", "달콤한", "구수한", "삼삼한", "밍밍한", "칼칼한"};
     private static final String[] FOOD_LIST = {"햄버거", "감자튀김", "감자탕", "닭발구이", "피자", "치킨", "비빔밥", "떡볶이", "갈비", "곱창전골", "삼겹살", "호떡", "만두", "물회", "연어", "타코야끼", "쌀국수", "냉면", "샤브샤브", "제육볶음", "쫄면", "붕어빵", "마라탕", "마라샹궈", "김치찌개", "된장찌개", "카레", "돈까스", "짬뽕", "짜장면", "유린기", "초밥", "딱새우", "칼국수", "새우튀김", "어묵우동", "육회", "가라아게", "콘스프", "간장새우", "파스타", "볶음밥", "소세지", "리조또", "깐풍기", "칠리새우", "크림새우", "군만두", "꿔바로우", "분짜", "스프링롤", "팟타이", "똠양꿍", "닭강정", "떡갈비", "핫도그", "샐러드", "닭갈비", "계란말이", "탄두리"};
 
     public static String generateRandomNickname() {
-        Random rand = new Random();
-        int flavorIdx = rand.nextInt(FLAVOR_LIST.length);
-        int foodIdx = rand.nextInt(FOOD_LIST.length);
-        return FLAVOR_LIST[flavorIdx] + " " + FOOD_LIST[foodIdx];
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int flavorIdx = random.nextInt(FLAVOR_LIST.length);
+        int foodIdx = random.nextInt(FOOD_LIST.length);
+        int randNum = random.nextInt(MIN_NUM_FOR_RANDOM_NICKNAME, MAX_NUM_FOR_RANDOM_NICKNAME);
+        return String.format("%s %s %d", FLAVOR_LIST[flavorIdx], FOOD_LIST[foodIdx], randNum);
     }
 }

--- a/src/main/java/com/zelusik/eatery/global/util/NicknameGenerator.java
+++ b/src/main/java/com/zelusik/eatery/global/util/NicknameGenerator.java
@@ -1,13 +1,16 @@
 package com.zelusik.eatery.global.util;
 
+import java.util.Random;
+
 public class NicknameGenerator {
 
     private static final String[] FLAVOR_LIST = {"달달한", "바삭한", "매콤한", "쫄깃한", "아삭한", "촉촉한", "고소한", "알싸한", "얼얼한", "얼큰한", "진한", "싱거운", "짭잘한", "짭조름한", "담백한", "느끼한", "새콤한", "신선한", "달콤한", "구수한", "삼삼한", "밍밍한", "칼칼한"};
     private static final String[] FOOD_LIST = {"햄버거", "감자튀김", "감자탕", "닭발구이", "피자", "치킨", "비빔밥", "떡볶이", "갈비", "곱창전골", "삼겹살", "호떡", "만두", "물회", "연어", "타코야끼", "쌀국수", "냉면", "샤브샤브", "제육볶음", "쫄면", "붕어빵", "마라탕", "마라샹궈", "김치찌개", "된장찌개", "카레", "돈까스", "짬뽕", "짜장면", "유린기", "초밥", "딱새우", "칼국수", "새우튀김", "어묵우동", "육회", "가라아게", "콘스프", "간장새우", "파스타", "볶음밥", "소세지", "리조또", "깐풍기", "칠리새우", "크림새우", "군만두", "꿔바로우", "분짜", "스프링롤", "팟타이", "똠양꿍", "닭강정", "떡갈비", "핫도그", "샐러드", "닭갈비", "계란말이", "탄두리"};
 
     public static String generateRandomNickname() {
-        int flavorIdx = (int) (Math.random() * FLAVOR_LIST.length);
-        int foodIdx = (int) (Math.random() * FOOD_LIST.length);
+        Random rand = new Random();
+        int flavorIdx = rand.nextInt(FLAVOR_LIST.length);
+        int foodIdx = rand.nextInt(FOOD_LIST.length);
         return FLAVOR_LIST[flavorIdx] + " " + FOOD_LIST[foodIdx];
     }
 }

--- a/src/test/java/com/zelusik/eatery/integration/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/member/repository/MemberRepositoryTest.java
@@ -125,7 +125,7 @@ class MemberRepositoryTest {
     }
 
     private Member createNewMember(String socialUid, String nickname) {
-        return Member.of(
+        return Member.create(
                 "https://default-profile-image",
                 "https://defualt-profile-thumbnail-image",
                 socialUid,

--- a/src/test/java/com/zelusik/eatery/integration/domain/place/repository/PlaceRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/place/repository/PlaceRepositoryTest.java
@@ -317,7 +317,7 @@ class PlaceRepositoryTest {
     }
 
     private Member createNewMember(String socialUid) {
-        return Member.of(
+        return Member.create(
                 "https://default-profile-image",
                 "https://defualt-profile-thumbnail-image",
                 socialUid,

--- a/src/test/java/com/zelusik/eatery/integration/domain/recommended_review/repository/RecommendedReviewRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/recommended_review/repository/RecommendedReviewRepositoryTest.java
@@ -109,7 +109,7 @@ class RecommendedReviewRepositoryTest {
     }
 
     private Member createNewMember(String socialId, Set<RoleType> roleTypes, String nickname) {
-        return Member.of(
+        return Member.create(
                 "https://default-profile-image",
                 "https://defualt-profile-thumbnail-image",
                 socialId,

--- a/src/test/java/com/zelusik/eatery/integration/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/domain/review/repository/ReviewRepositoryTest.java
@@ -316,7 +316,7 @@ class ReviewRepositoryTest {
     }
 
     private Member createNewMember(String socialUid, Set<RoleType> roleTypes) {
-        return Member.of(
+        return Member.create(
                 "https://default-profile-image",
                 "https://defualt-profile-thumbnail-image",
                 socialUid,

--- a/src/test/java/com/zelusik/eatery/unit/domain/bookmark/service/BookmarkCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/bookmark/service/BookmarkCommandServiceTest.java
@@ -147,7 +147,7 @@ class BookmarkCommandServiceTest {
     }
 
     private Member createMember(long memberId) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberCommandServiceTest.java
@@ -214,7 +214,7 @@ class MemberCommandServiceTest {
     }
 
     private Member createDeletedMember(long memberId) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",
@@ -237,7 +237,7 @@ class MemberCommandServiceTest {
     }
 
     private Member createMember(long memberId, Set<RoleType> roleTypes) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/member/service/MemberQueryServiceTest.java
@@ -161,7 +161,7 @@ class MemberQueryServiceTest {
     }
 
     private Member createMember(long memberId, Set<RoleType> roleTypes) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/menu_keyword/api/MenuKeywordControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/menu_keyword/api/MenuKeywordControllerTest.java
@@ -1,18 +1,18 @@
 package com.zelusik.eatery.unit.domain.menu_keyword.api;
 
 import com.zelusik.eatery.config.TestSecurityConfig;
-import com.zelusik.eatery.global.common.constant.EateryConstants;
-import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
 import com.zelusik.eatery.domain.member.constant.Gender;
 import com.zelusik.eatery.domain.member.constant.LoginType;
 import com.zelusik.eatery.domain.member.constant.RoleType;
-import com.zelusik.eatery.domain.menu_keyword.api.MenuKeywordController;
-import com.zelusik.eatery.domain.place.entity.PlaceCategory;
-import com.zelusik.eatery.global.common.dto.ListDto;
 import com.zelusik.eatery.domain.member.dto.MemberDto;
+import com.zelusik.eatery.domain.menu_keyword.api.MenuKeywordController;
 import com.zelusik.eatery.domain.menu_keyword.dto.response.MenuKeywordResponse;
-import com.zelusik.eatery.global.auth.UserPrincipal;
 import com.zelusik.eatery.domain.menu_keyword.service.MenuKeywordQueryService;
+import com.zelusik.eatery.domain.place.entity.PlaceCategory;
+import com.zelusik.eatery.global.auth.UserPrincipal;
+import com.zelusik.eatery.global.common.constant.EateryConstants;
+import com.zelusik.eatery.global.common.constant.FoodCategoryValue;
+import com.zelusik.eatery.global.common.dto.ListDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,9 +29,9 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Set;
 
-import static com.zelusik.eatery.global.common.constant.EateryConstants.API_MINOR_VERSION_HEADER_NAME;
 import static com.zelusik.eatery.domain.review_keyword.constant.MenuKeywordCategory.MENU_NAME;
 import static com.zelusik.eatery.domain.review_keyword.constant.MenuKeywordCategory.PLACE_CATEGORY;
+import static com.zelusik.eatery.global.common.constant.EateryConstants.API_MINOR_VERSION_HEADER_NAME;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/zelusik/eatery/unit/domain/profile_image/service/ProfileImageCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/profile_image/service/ProfileImageCommandServiceTest.java
@@ -12,6 +12,7 @@ import com.zelusik.eatery.global.file.service.S3FileService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.ReflectionUtils;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -75,7 +76,7 @@ class ProfileImageCommandServiceTest {
     }
 
     private Member createMember(long memberId) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/profile_image/service/ProfileImageQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/profile_image/service/ProfileImageQueryServiceTest.java
@@ -52,7 +52,7 @@ class ProfileImageQueryServiceTest {
     }
 
     private Member createMember(long memberId) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/service/RecommendedReviewCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/recommended_review/service/RecommendedReviewCommandServiceTest.java
@@ -136,7 +136,7 @@ class RecommendedReviewCommandServiceTest {
     }
 
     private Member createMember(Long memberId, Set<RoleType> roleTypes) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewCommandServiceTest.java
@@ -192,7 +192,7 @@ class ReviewCommandServiceTest {
     }
 
     private Member createMember(Long memberId, Set<RoleType> roleTypes) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewQueryServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/review/service/ReviewQueryServiceTest.java
@@ -166,7 +166,7 @@ class ReviewQueryServiceTest {
     }
 
     private Member createMember(Long memberId, Set<RoleType> roleTypes) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/review_image/service/ReviewImageCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/review_image/service/ReviewImageCommandServiceTest.java
@@ -123,7 +123,7 @@ class ReviewImageCommandServiceTest {
     }
 
     private Member createMember(long memberId, Set<RoleType> roleTypes) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/domain/terms_info/service/TermsInfoCommandServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/domain/terms_info/service/TermsInfoCommandServiceTest.java
@@ -98,7 +98,7 @@ class TermsInfoCommandServiceTest {
     }
 
     private Member createMember(long memberId, Set<RoleType> roleTypes) {
-        return Member.of(
+        return new Member(
                 memberId,
                 "profile image url",
                 "profile thunmbnail image url",

--- a/src/test/java/com/zelusik/eatery/unit/global/util/NicknameGeneratorTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/global/util/NicknameGeneratorTest.java
@@ -1,0 +1,5 @@
+package com.zelusik.eatery.unit.global.util;
+
+class NicknameGeneratorTest {
+
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #383 

## 🏃‍ Task
-  회원 닉네임 정책 적용하여 코드 수정
   - 최소 길이: 2
   - 최대 길이: 10
   - 중복 허용: X
   - 중복 방지를 위해 기존 랜덤 닉네임 생성 로직에 숫자 포함하여 생성하도록 수정.


## 📄 Reference
- None
