### PR TITLE
`FoodCategoryValue`에 미등록 데이터 추가

### DIFF
--- a/src/main/java/com/zelusik/eatery/global/common/constant/FoodCategoryValue.java
+++ b/src/main/java/com/zelusik/eatery/global/common/constant/FoodCategoryValue.java
@@ -35,7 +35,7 @@ public enum FoodCategoryValue {
     WESTERN("양식", List.of("양식")),
     CHICKEN("치킨", List.of("치킨")),
     STREET("분식", List.of("분식")),
-    MEAT("고기/구이", List.of("육류,고기")),
+    MEAT("고기/구이", List.of()),
     FAST_FOOD("패스트푸드", List.of("패스트푸드", "구내식당", "푸드코트", "여가시설", "전문대행")),
     CAFE_DESSERT("카페/디저트", List.of("카페", "간식")),
     ASIAN("아시안푸드", List.of("아시아음식")),

--- a/src/main/java/com/zelusik/eatery/global/common/constant/FoodCategoryValue.java
+++ b/src/main/java/com/zelusik/eatery/global/common/constant/FoodCategoryValue.java
@@ -7,24 +7,7 @@ import lombok.Getter;
 import java.util.Arrays;
 import java.util.List;
 
-@Schema(description = "<p>음식 종류. 목록은 다음과 같다." +
-                      "<ul>" +
-                      "   <li><code>KOREAN</code> - 한식</li>" +
-                      "   <li><code>JAPANESE</code> - 일식</li>" +
-                      "   <li><code>CHINESE</code> - 중식</li>" +
-                      "   <li><code>WESTERN</code> - 양식</li>" +
-                      "   <li><code>MEAT</code> - 고기/구이</li>" +
-                      "   <li><code>CHICKEN</code> - 치킨</li>" +
-                      "   <li><code>STREET</code> - 분식</li>" +
-                      "   <li><code>FAST_FOOD</code> - 패스트푸드</li>" +
-                      "   <li><code>CAFE_DESSERT</code> - 카페/디저트</li>" +
-                      "   <li><code>ASIAN</code> - 아시안푸드</li>" +
-                      "   <li><code>SANDWICH</code> - 샌드위치</li>" +
-                      "   <li><code>FUSION_WORLD</code> - 퓨전/세계</li>" +
-                      "   <li><code>BUFFET</code> - 뷔페</li>" +
-                      "   <li><code>BAR</code> - 술집</li>" +
-                      "</ul>",
-        example = "KOREAN")
+@Schema(description = "Eatery 음식/음식점 카테고리")
 @AllArgsConstructor
 @Getter
 public enum FoodCategoryValue {

--- a/src/main/java/com/zelusik/eatery/global/common/constant/FoodCategoryValue.java
+++ b/src/main/java/com/zelusik/eatery/global/common/constant/FoodCategoryValue.java
@@ -36,7 +36,7 @@ public enum FoodCategoryValue {
     CHICKEN("치킨", List.of("치킨")),
     STREET("분식", List.of("분식")),
     MEAT("고기/구이", List.of("육류,고기")),
-    FAST_FOOD("패스트푸드", List.of("패스트푸드")),
+    FAST_FOOD("패스트푸드", List.of("패스트푸드", "구내식당", "푸드코트", "여가시설", "전문대행")),
     CAFE_DESSERT("카페/디저트", List.of("카페", "간식")),
     ASIAN("아시안푸드", List.of("아시아음식")),
     SANDWICH("샌드위치", List.of("샌드위치", "샐러드")),


### PR DESCRIPTION
## 🔥 Related Issue
- Close #409

## 🏃‍ Task
- `FoodCategoryValue`에 미등록 데이터 추가
  - 전문대행
  - 푸드코트
  - 여가시설
  - 구내식당
- 불필요한 "고기/구이" 음식점 카테고리 mapping value 제거

## 📄 Reference
- [잇터리 음식 카테고리 리스트](https://www.notion.so/asdfqweasd/ed8432921ed34bd5b0259c2fbb6eb953?pvs=4)
