### PR TITLE
회원 정보 수정 시 NicknameDuplicationException 발생하는 문제 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/zelusik/eatery/domain/member/service/MemberCommandService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -80,7 +81,10 @@ public class MemberCommandService {
     public MemberDto update(Long memberId, MemberUpdateRequest updateRequest) {
         Member member = memberQueryService.getById(memberId);
 
-        validateNicknameDuplication(updateRequest.getNickname());
+        // 닉네임을 변경했다면, 변경하고자 하는 닉네임이 이미 사용중이지 않은지 확인
+        if (!Objects.equals(member.getNickname(), updateRequest.getNickname())) {
+            validateNicknameDuplication(updateRequest.getNickname());
+        }
 
         MultipartFile profileImageForUpdate = updateRequest.getProfileImage();
         if (profileImageForUpdate == null) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #432

## 🏃‍ Task
- 회원 정보 수정 기능 닉네임 중복 체크 로직 수정: 회원 정보 수정 시, 닉네임이 변경된 경우에만 닉네임 중복 확인 로직이 실행되도록 수정

## 📄 Reference
- None
